### PR TITLE
Added smarts substructure filter and tests.

### DIFF
--- a/qcsubmit/tests/test_workflow_components.py
+++ b/qcsubmit/tests/test_workflow_components.py
@@ -211,6 +211,7 @@ def test_weight_filter_validator():
         pytest.param((workflow_components.EnumerateTautomers, "max_tautomers", 2), id="EnumerateTautomers"),
         pytest.param((workflow_components.EnumerateStereoisomers, "undefined_only", True), id="EnumerateStereoisomers"),
         pytest.param((workflow_components.RotorFilter, "maximum_rotors", 3), id="RotorFilter"),
+        pytest.param((workflow_components.SmartsFilter, "allowed_substructures", ["[C:1]-[C:2]"]), id="SmartsFilter")
     ],
 )
 def test_to_from_object(data):
@@ -475,3 +476,78 @@ def test_rotor_filter():
     result = rotor_filter.apply(molecule_container.molecules)
     for molecule in result.molecules:
         assert len(molecule.find_rotatable_bonds()) <= rotor_filter.maximum_rotors
+
+
+def test_environment_filter_validator():
+    """
+    Make sure the validator is checking the allowed and filtered fields have valid smirks strings.
+    """
+
+    from openforcefield.typing.chemistry import ChemicalEnvironment, SMIRKSParsingError
+
+    filter = workflow_components.SmartsFilter()
+
+    with pytest.raises(SMIRKSParsingError):
+        filter.allowed_substructures = [1, 2, 3, 4]
+
+    with pytest.raises(SMIRKSParsingError):
+        filter.allowed_substructures = ["fkebfsjb"]
+
+    with pytest.raises(SMIRKSParsingError):
+        filter.allowed_substructures = ["[C:1]-[C:2]", "ksbfsb"]
+
+    filter.allowed_substructures = [ChemicalEnvironment("[C:1]=[C:2]")]
+
+    assert len(filter.allowed_substructures) == 1
+
+
+def test_environment_filter_apply_parameters():
+    """
+    Make sure the environment filter is correctly identifying substructures.
+    """
+
+    filter = workflow_components.SmartsFilter()
+
+    # this should only allow C, H, N, O containing molecules through similar to the element filter
+    filter.allowed_substructures = ["[C:1]", "[c:1]", "[H:1]", "[O:1]", "[N:1]"]
+    filter.filtered_substructures = ["[Cl:1]", "[F:1]", "[P:1]", "[Br:1]", "[S:1]", "[I:1]", "[B:1]"]
+    allowed_elements = [1, 6, 7, 8]
+
+    molecules = get_molecues(incude_undefined_stereo=False, include_conformers=False)
+
+    result = filter.apply(molecules)
+
+    assert result.component_name == filter.component_name
+    assert result.component_description == filter.dict()
+    # make sure there are no unwanted elements in the pass set
+    for molecule in result.molecules:
+        for atom in molecule.atoms:
+            assert atom.atomic_number in allowed_elements, print(molecule)
+
+    for molecule in result.filtered:
+        elements = set([atom.atomic_number for atom in molecule.atoms])
+        assert sorted(elements) != sorted(allowed_elements)
+
+
+def test_environment_filter_apply_none():
+    """
+    Make sure we get the expected behaviour when we supply None as the filter list.
+    """
+
+    filter = workflow_components.SmartsFilter()
+
+    filter.allowed_substructures = None
+
+    molecules = get_molecues(incude_undefined_stereo=False, include_conformers=False)
+
+    # this should allow all molecules through
+    result = filter.apply(molecules=molecules)
+
+    assert len(result.molecules) == len(molecules)
+
+    # now filter the molecule set again removing aromatic carbons
+    filter.filtered_substructures = ["[c:1]"]
+
+    result2 = filter.apply(molecules=result.molecules)
+
+    assert len(result2.molecules) != result.molecules

--- a/qcsubmit/tests/test_workflow_components.py
+++ b/qcsubmit/tests/test_workflow_components.py
@@ -483,7 +483,7 @@ def test_environment_filter_validator():
     Make sure the validator is checking the allowed and filtered fields have valid smirks strings.
     """
 
-    from openforcefield.typing.chemistry import ChemicalEnvironment, SMIRKSParsingError
+    from openforcefield.typing.chemistry import SMIRKSParsingError
 
     filter = workflow_components.SmartsFilter()
 
@@ -502,8 +502,8 @@ def test_environment_filter_validator():
         # good smarts with no tagged atoms.
         filter.allowed_substructures = ["[C]=[C]"]
 
-    filter.allowed_substructures = [ChemicalEnvironment("[C:1]=[C:2]")]
-
+    # a good search string
+    filter.allowed_substructures = ["[C:1]=[C:2]"]
     assert len(filter.allowed_substructures) == 1
 
 

--- a/qcsubmit/tests/test_workflow_components.py
+++ b/qcsubmit/tests/test_workflow_components.py
@@ -491,10 +491,16 @@ def test_environment_filter_validator():
         filter.allowed_substructures = [1, 2, 3, 4]
 
     with pytest.raises(SMIRKSParsingError):
+        # bad string
         filter.allowed_substructures = ["fkebfsjb"]
 
     with pytest.raises(SMIRKSParsingError):
+        # make sure each item is checked
         filter.allowed_substructures = ["[C:1]-[C:2]", "ksbfsb"]
+
+    with pytest.raises(SMIRKSParsingError):
+        # good smarts with no tagged atoms.
+        filter.allowed_substructures = ["[C]=[C]"]
 
     filter.allowed_substructures = [ChemicalEnvironment("[C:1]=[C:2]")]
 

--- a/qcsubmit/workflow_components/__init__.py
+++ b/qcsubmit/workflow_components/__init__.py
@@ -1,5 +1,11 @@
 from .base_component import BasicSettings, CustomWorkflowComponent, ToolkitValidator
 from .conformer_generation import StandardConformerGenerator
-from .filters import CoverageFilter, ElementFilter, MolecularWeightFilter, RotorFilter
+from .filters import (
+    CoverageFilter,
+    ElementFilter,
+    MolecularWeightFilter,
+    RotorFilter,
+    SmartsFilter,
+)
 from .fragmentation import WBOFragmenter
 from .state_enumeration import EnumerateStereoisomers, EnumerateTautomers

--- a/qcsubmit/workflow_components/filters.py
+++ b/qcsubmit/workflow_components/filters.py
@@ -1,6 +1,7 @@
 """
 File containing the filters workflow components.
 """
+import re
 from typing import Dict, List, Optional, Union
 
 from pydantic import validator
@@ -364,10 +365,11 @@ class SmartsFilter(BasicSettings, CustomWorkflowComponent):
         Check the the string passed is valid by trying to create a ChemicalEnvironment in the toolkit.
         """
 
-        # try and make a new chemical environment
-        valid_env = ChemicalEnvironment(smirks=environment)
+        # try and make a new chemical environment checking for parse errors
+        _ = ChemicalEnvironment(smirks=environment)
 
-        if valid_env.getIndexedAtoms():
+        # check for numeric tags in the environment
+        if re.search(":[0-9]]+", environment) is not None:
             return environment
 
         else:

--- a/qcsubmit/workflow_components/filters.py
+++ b/qcsubmit/workflow_components/filters.py
@@ -6,6 +6,10 @@ from typing import Dict, List, Optional, Union
 from pydantic import validator
 
 from openforcefield.topology import Molecule
+from openforcefield.typing.chemistry.environment import (
+    ChemicalEnvironment,
+    SMIRKSParsingError,
+)
 from openforcefield.typing.engines.smirnoff import ForceField
 from openforcefield.utils.structure import get_molecule_parameterIDs
 from qcsubmit.datasets import ComponentResult
@@ -332,5 +336,81 @@ class RotorFilter(BasicSettings, CustomWorkflowComponent):
 
             else:
                 result.add_molecule(molecule)
+
+        return result
+
+
+class SmartsFilter(BasicSettings, CustomWorkflowComponent):
+    """
+    Filters molecules based on if they contain certain smarts substructures.
+
+    Note:
+        * The smarts tags used for filtering should be numerically tagged in order to work with the toolkit.
+        * If None is passed to the allowed list all molecules that dont match a filter pattern will be passed.
+    """
+
+    component_name = "SmartsFilter"
+    component_description = "Filter molecules based on the given smarts patterns."
+    component_fail_message = (
+        "The molecule did/didn't contain the given smarts patterns."
+    )
+
+    allowed_substructures: Optional[List[Union[str, ChemicalEnvironment]]] = None
+    filtered_substructures: Optional[List[Union[str, ChemicalEnvironment]]] = None
+
+    @validator("allowed_substructures", "filtered_substructures", each_item=True)
+    def _check_environments(cls, environment):
+        """
+        Check the the string passed is valid by trying to create a ChemicalEnvironment in the toolkit.
+        """
+
+        if isinstance(environment, ChemicalEnvironment):
+            return environment
+
+        else:
+            # try and make a new chemical environment
+            valid_env = ChemicalEnvironment(smirks=environment)
+            return valid_env
+
+    def apply(self, molecules: List[Molecule]) -> ComponentResult:
+        """
+        Apply the filter to the input list of molecules removing those that match the filtered set or do not contain an
+        allowed substructure.
+
+        Parameters:
+            molecules: The list of molecules the component should be applied on.
+
+        Returns:
+            A [ComponentResult][qcsubmit.datasets.ComponentResult] instance containing information about the molecules
+            that passed and were filtered by the component and details about the component which generated the result.
+        """
+
+        # create the return
+        result = self._create_result()
+
+        if self.allowed_substructures is None:
+            # pass all of the molecules
+            result.molecules = molecules
+
+        else:
+            for molecule in molecules:
+                for substructure in self.allowed_substructures:
+                    if molecule.chemical_environment_matches(query=substructure):
+                        result.add_molecule(molecule=molecule)
+                        break
+                else:
+                    self.fail_molecule(molecule=molecule, component_result=result)
+
+        if self.filtered_substructures is not None:
+            # now we only want to check the molecules in the pass list
+            molecules_to_remove = []
+            for molecule in result.molecules:
+                for substructure in self.filtered_substructures:
+                    if molecule.chemical_environment_matches(query=substructure):
+                        molecules_to_remove.append(molecule)
+                        break
+
+            for molecule in molecules_to_remove:
+                self.fail_molecule(molecule=molecule, component_result=result)
 
         return result

--- a/qcsubmit/workflow_components/filters.py
+++ b/qcsubmit/workflow_components/filters.py
@@ -375,8 +375,10 @@ class SmartsFilter(BasicSettings, CustomWorkflowComponent):
             return environment
 
         else:
-            raise SMIRKSParsingError("The smarts pattern passed had no tagged atoms please tag the atoms in the "
-                                     "substructure you wish to include/exclude.")
+            raise SMIRKSParsingError(
+                "The smarts pattern passed had no tagged atoms please tag the atoms in the "
+                "substructure you wish to include/exclude."
+            )
 
     def apply(self, molecules: List[Molecule]) -> ComponentResult:
         """

--- a/qcsubmit/workflow_components/filters.py
+++ b/qcsubmit/workflow_components/filters.py
@@ -364,13 +364,19 @@ class SmartsFilter(BasicSettings, CustomWorkflowComponent):
         Check the the string passed is valid by trying to create a ChemicalEnvironment in the toolkit.
         """
 
-        if isinstance(environment, ChemicalEnvironment):
+        if not isinstance(environment, ChemicalEnvironment):
+            # try and make a new chemical environment
+            valid_env = ChemicalEnvironment(smirks=environment)
+
+        else:
+            valid_env = environment
+
+        if valid_env.getIndexedAtoms():
             return environment
 
         else:
-            # try and make a new chemical environment
-            valid_env = ChemicalEnvironment(smirks=environment)
-            return valid_env
+            raise SMIRKSParsingError("The smarts pattern passed had no tagged atoms please tag the atoms in the "
+                                     "substructure you wish to include/exclude.")
 
     def apply(self, molecules: List[Molecule]) -> ComponentResult:
         """

--- a/qcsubmit/workflow_components/filters.py
+++ b/qcsubmit/workflow_components/filters.py
@@ -355,8 +355,8 @@ class SmartsFilter(BasicSettings, CustomWorkflowComponent):
         "The molecule did/didn't contain the given smarts patterns."
     )
 
-    allowed_substructures: Optional[List[Union[str, ChemicalEnvironment]]] = None
-    filtered_substructures: Optional[List[Union[str, ChemicalEnvironment]]] = None
+    allowed_substructures: Optional[List[str]] = None
+    filtered_substructures: Optional[List[str]] = None
 
     @validator("allowed_substructures", "filtered_substructures", each_item=True)
     def _check_environments(cls, environment):
@@ -364,12 +364,8 @@ class SmartsFilter(BasicSettings, CustomWorkflowComponent):
         Check the the string passed is valid by trying to create a ChemicalEnvironment in the toolkit.
         """
 
-        if not isinstance(environment, ChemicalEnvironment):
-            # try and make a new chemical environment
-            valid_env = ChemicalEnvironment(smirks=environment)
-
-        else:
-            valid_env = environment
+        # try and make a new chemical environment
+        valid_env = ChemicalEnvironment(smirks=environment)
 
         if valid_env.getIndexedAtoms():
             return environment


### PR DESCRIPTION
## Description
- [X]  implements  #10

## Todos
Molecules can now be filtered depending on if they contain certain allowed/disallowed substructures defined as tagged smarts patterns. 

## Questions
- [x] Due to the use of the toolkit `chemical_environment_matches` function the search smarts must be tagged by at least one atom but the chemical environment check allows untagged patterns to be validated without error, should we also check for numeric tags.

## Status
- [x] Ready to go