### PR TITLE
Check torsion connections

### DIFF
--- a/qcsubmit/tests/test_factories.py
+++ b/qcsubmit/tests/test_factories.py
@@ -445,6 +445,24 @@ def test_torsiondrive_linear_torsion():
         assert bool(factory._detect_linear_torsions(molecule)) is True
 
 
+def test_torsiondrive_unconnected_torsions():
+    """
+    Test the torsiondrive factory when removing highlighted torsions which are not connected.
+    """
+
+    factory = TorsiondriveDatasetFactory()
+    ethanol = Molecule.from_file(get_data("methanol.sdf"), "sdf")
+
+    # tag a correct dihedral with scrambled index
+    assert factory._check_torsion_connection((5, 1, 4, 0), ethanol) is False
+
+    # tag atoms not in the molecule
+    assert factory._check_torsion_connection((12, 22, 23, 45), ethanol) is False
+
+    # tag a valid torsion
+    assert factory._check_torsion_connection((5, 1, 0, 4), ethanol) is True
+
+
 def test_torsiondrive_torsion_string():
     """
     Test the torsiondrive factories ability to create a torsion string for a given bond.


### PR DESCRIPTION
## Description
- [X] Fixes #8 
- [x] Tests added 
- [X] Docs updated

## Todos
This now means that molecules with torsions highlighted by a component or some outside source are checked that they are connected before making the dataset, if they are not the molecule is failed.

## Status
- [X] Ready to go