### PR TITLE
Basis set coverage checking

### DIFF
--- a/devtools/conda-envs/ani_env.yaml
+++ b/devtools/conda-envs/ani_env.yaml
@@ -25,3 +25,4 @@ dependencies:
     # Pip-only installs
   - pip:
     - torchani
+    - basis_set_exchange

--- a/devtools/conda-envs/psi4_env.yaml
+++ b/devtools/conda-envs/psi4_env.yaml
@@ -25,5 +25,5 @@ dependencies:
   - openeye-toolkits
 
     # Pip-only installs
-#  - pip:
-#    - torchani
+  - pip:
+    - basis_set_exchange

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -22,5 +22,5 @@ dependencies:
   - openeye-toolkits
 
     # Pip-only installs
-#  - pip:
-#    - torchani
+  - pip:
+    - basis_set_exchange

--- a/qcsubmit/common_structures.py
+++ b/qcsubmit/common_structures.py
@@ -85,12 +85,6 @@ class Metadata(DatasetConfig):
     long_description: Optional[str] = None
     elements: Set[str] = set()
 
-    @validator("elements", each_item=True)
-    def _check_elements(cls, element):
-        """
-        Make sure that each element given is valid and saved as a symbol
-        """
-
     @validator("short_description", "long_description")
     def _check_strings(cls, string):
         """

--- a/qcsubmit/common_structures.py
+++ b/qcsubmit/common_structures.py
@@ -4,7 +4,7 @@ This file contains common starting structures which can be mixed into datasets, 
 import getpass
 import re
 from datetime import date, datetime
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 import numpy as np
 from pydantic import BaseModel, HttpUrl, validator
@@ -83,6 +83,13 @@ class Metadata(DatasetConfig):
     short_description: Optional[str] = None
     long_description_url: Optional[HttpUrl] = None
     long_description: Optional[str] = None
+    elements: Set[str] = set()
+
+    @validator("elements", each_item=True)
+    def _check_elements(cls, element):
+        """
+        Make sure that each element given is valid and saved as a symbol
+        """
 
     @validator("short_description", "long_description")
     def _check_strings(cls, string):

--- a/qcsubmit/exceptions.py
+++ b/qcsubmit/exceptions.py
@@ -82,3 +82,12 @@ class DatasetInputError(QCSubmitException):
 
     error_type = "dataset_input_error"
     header = "Dataset Input Error"
+
+
+class MissingBasisCoverageError(QCSubmitException):
+    """
+    The basis set selected does not contain element coverage for all atoms in the dataset.
+    """
+
+    error_type = "missing_basis_coverage_error"
+    header = "Missing Basis Coverage Error"

--- a/qcsubmit/workflow_components/filters.py
+++ b/qcsubmit/workflow_components/filters.py
@@ -157,7 +157,7 @@ class ElementFilter(BasicSettings, CustomWorkflowComponent):
                 return element
             except KeyError:
                 raise KeyError(
-                    f"An element could not be determined from symbol {element}, please eneter symbols only."
+                    f"An element could not be determined from symbol {element}, please enter symbols only."
                 )
 
     def apply(self, molecules: List[Molecule]) -> ComponentResult:


### PR DESCRIPTION
## Description
- [X]  implements #13 

## Todos
- [x] Check ani1 methods for coverage
- [x] Check psi4 basis set name converter
- [x] Check using the basis set exchange python package

## Questions
- [ ] Are there any other basis set naming differences between psi4 and the basis set exchange that we should add? Currently, we have `DZVP` -> `dgauss-dzvp`

## Status
- [x] Ready to go