### PR TITLE
Dataset combining

### DIFF
--- a/qcsubmit/constraints.py
+++ b/qcsubmit/constraints.py
@@ -191,3 +191,15 @@ class Constraints(ResultsConfig):
             if not constraints:
                 drop_constraints.add(constraint)
         return super().dict(exclude=drop_constraints)
+
+    def __eq__(self, other: "Constraints") -> bool:
+        """
+        Check that all constraints are the same before returning.
+        """
+        for set_con in self.set:
+            if set_con not in other.set:
+                return False
+        for freeze_con in self.freeze:
+            if freeze_con not in other.freeze:
+                return False
+        return True

--- a/qcsubmit/datasets.py
+++ b/qcsubmit/datasets.py
@@ -207,8 +207,6 @@ class ComponentResult:
         finally:
             if molecule not in self.filtered:
                 self.filtered.append(molecule)
-            else:
-                return
 
     def __repr__(self):
         return f"ComponentResult(name={self.component_name}, molecules={self.n_molecules}, filtered={self.n_filtered})"
@@ -447,10 +445,6 @@ class BasicDataset(IndexCleaner, ClientHandler, DatasetConfig):
             if not entry_ids:
                 new_dataset.dataset[index] = entry
             else:
-                # work out if the mapping is the same
-                assert len(entry_ids) == 1, print(
-                    "The molecule appears more than once in the dataset."
-                )
                 mol_id = entry_ids[0]
                 current_entry = new_dataset.dataset[mol_id]
                 _, atom_map = off.Molecule.are_isomorphic(
@@ -712,7 +706,9 @@ class BasicDataset(IndexCleaner, ClientHandler, DatasetConfig):
             if covered_elements is not None:
                 difference = self.metadata.elements.difference(covered_elements)
             else:
-                raise ValueError(f"The torchani method {self.method} is not supported.")
+                raise MissingBasisCoverageError(
+                    f"The torchani method {self.method} is not supported."
+                )
 
         elif self.program.lower() == "psi4":
             # now check psi4
@@ -868,7 +864,7 @@ class BasicDataset(IndexCleaner, ClientHandler, DatasetConfig):
         else:
             raise UnsupportedFiletypeError(
                 f"The requested file type {file_type} is not supported please use "
-                f"json or yaml"
+                f"json."
             )
 
     def coverage_report(self, forcefields: List[str]) -> Dict:
@@ -896,7 +892,9 @@ class BasicDataset(IndexCleaner, ClientHandler, DatasetConfig):
             "n": "vdW",
         }
         if isinstance(forcefields, str):
-            forcefields = [forcefields]
+            forcefields = [
+                forcefields,
+            ]
 
         for forcefield in forcefields:
 

--- a/qcsubmit/exceptions.py
+++ b/qcsubmit/exceptions.py
@@ -124,3 +124,12 @@ class ConstraintError(QCSubmitException):
 
     error_type = "constraint_error"
     header = "Constraint Error"
+
+
+class DatasetCombinationError(QCSubmitException):
+    """
+    The types of dataset are not the same and can not be combined.
+    """
+
+    error_type = "dataset combination error"
+    header = "Dataset Combination Error"

--- a/qcsubmit/tests/test_results.py
+++ b/qcsubmit/tests/test_results.py
@@ -353,7 +353,7 @@ def test_torsiondrivedataset_new_optimization(public_client):
                                                      tagline="a test optimization dataset.")
 
     assert new_dataset.dataset_name == "new optimization dataset"
-    assert new_dataset.n_molecules == 24
+    assert new_dataset.n_molecules == 1
     assert new_dataset.n_records == 24
     dihedrals = set()
     for entry in new_dataset.dataset.values():

--- a/qcsubmit/utils.py
+++ b/qcsubmit/utils.py
@@ -1,4 +1,6 @@
-from typing import List
+from typing import Dict, List
+
+from openforcefield import topology as off
 
 
 def get_data(relative_path):
@@ -32,3 +34,25 @@ def clean_strings(string_list: List[str]) -> List[str]:
         new_string = string.strip()
         clean_string.append(new_string.strip(","))
     return clean_string
+
+
+def remap_list(target_list: List[int], mapping: Dict[int, int]) -> List[int]:
+    """
+    Take a list of atom indices and remap them using the given mapping.
+    """
+    return [mapping[x] for x in target_list]
+
+
+def condense_molecules(molecules: List[off.Molecule]) -> off.Molecule:
+    """
+    Take a list of identical molecules in different conformers and collapse them making sure that they are in the same order.
+    """
+    molecule = molecules.pop()
+    for conformer in molecules:
+        _, atom_map = off.Molecule.are_isomorphic(
+            conformer, molecule, return_atom_map=True
+        )
+        mapped_mol = conformer.remap(atom_map)
+        for geometry in mapped_mol.conformers:
+            molecule.add_conformer(geometry)
+    return molecule

--- a/qcsubmit/workflow_components/fragmentation.py
+++ b/qcsubmit/workflow_components/fragmentation.py
@@ -147,7 +147,8 @@ class WBOFragmenter(ToolkitValidator, CustomWorkflowComponent):
                 elif not fragmets_dict and not self.include_parent:
                     self.fail_molecule(molecule=molecule, component_result=result)
 
-            except RuntimeError:
+            except (RuntimeError, ValueError):
+                # this will catch cmiles errors for molecules with undefined stero
                 self.fail_molecule(molecule=molecule, component_result=result)
 
         return result


### PR DESCRIPTION
## Description
This PR allows datasets to be combined into larger datasets via `new_dataset = dataset1 + dataset2`. 
Dataset types must match as the datasets have different definitions of equal entries and deduplication is applied to initial molecules.


## Status
- [X] Ready to go