### PR TITLE
Qcspec refactor

### DIFF
--- a/qcsubmit/common_structures.py
+++ b/qcsubmit/common_structures.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 import numpy as np
 import qcportal as ptl
+from qcelemental.models.results import WavefunctionProtocolEnum
 from pydantic import BaseModel, HttpUrl, constr, validator
 
 from qcsubmit.exceptions import DatasetInputError
@@ -34,6 +35,32 @@ class ResultsConfig(BaseModel):
         arbitrary_types_allowed: bool = True
         allow_mutation: bool = False
         json_encoders: Dict[str, Any] = {np.ndarray: lambda v: v.flatten().tolist()}
+
+
+class QCSpec(ResultsConfig):
+
+    method: constr(strip_whitespace=True) = "B3LYP-D3BJ"
+    basis: Optional[constr(strip_whitespace=True)] = "DZVP"
+    program: str = "psi4"
+    spec_name: str = "default"
+    spec_description: str = "Standard OpenFF optimization quantum chemistry specification."
+    store_wavefunction: WavefunctionProtocolEnum = WavefunctionProtocolEnum.none
+
+    def dict(
+        self,
+        *,
+        include: Union['AbstractSetIntStr', 'MappingIntStrAny'] = None,
+        exclude: Union['AbstractSetIntStr', 'MappingIntStrAny'] = None,
+        by_alias: bool = False,
+        skip_defaults: bool = None,
+        exclude_unset: bool = False,
+        exclude_defaults: bool = False,
+        exclude_none: bool = False,
+    ) -> 'DictStrAny':
+
+        data = super().dict(exclude={"store_wavefunction"})
+        data["store_wavefunction"] = self.store_wavefunction.value
+        return data
 
 
 def order_torsion(torsion: Tuple[int, int, int, int]) -> Tuple[int, int, int, int]:

--- a/qcsubmit/common_structures.py
+++ b/qcsubmit/common_structures.py
@@ -8,11 +8,11 @@ from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 import numpy as np
 import qcportal as ptl
-from qcelemental.models.results import WavefunctionProtocolEnum
 from pydantic import BaseModel, HttpUrl, constr, validator
+from qcelemental.models.results import WavefunctionProtocolEnum
 from qcfractal.interface import FractalClient
 
-from qcsubmit.exceptions import DatasetInputError
+from qcsubmit.exceptions import DatasetInputError, QCSpecificationError
 
 
 class DatasetConfig(BaseModel):
@@ -47,21 +47,180 @@ class QCSpec(ResultsConfig):
     spec_description: str = "Standard OpenFF optimization quantum chemistry specification."
     store_wavefunction: WavefunctionProtocolEnum = WavefunctionProtocolEnum.none
 
+    def __init__(
+        self,
+        method: constr(strip_whitespace=True) = "B3LYP-D3BJ",
+        basis: Optional[constr(strip_whitespace=True)] = "DZVP",
+        program: str = "psi4",
+        spec_name: str = "default",
+        spec_description: str = "Standard OpenFF optimization quantum chemistry specification.",
+        store_wavefunction: WavefunctionProtocolEnum = WavefunctionProtocolEnum.none,
+    ):
+        """
+        Validate the combination of method, basis and program.
+        """
+        from openforcefield.typing.engines.smirnoff import get_available_force_fields
+        from openmmforcefields.generators.template_generators import (
+            GAFFTemplateGenerator,
+        )
+
+        # set up the valid method basis and program combinations
+        ani_methods = {"ani1x", "ani1ccx", "ani2x"}
+        openff_forcefields = list(
+            ff.split(".offxml")[0] for ff in get_available_force_fields()
+        )
+        gaff_forcefields = GAFFTemplateGenerator.INSTALLED_FORCEFIELDS
+        xtb_methods = {
+            "gfn0-xtb",
+            "gfn0xtb",
+            "gfn1-xtb",
+            "gfn1xtb",
+            "gfn2-xtb",
+            "gfn2xtb",
+            "gfn-ff",
+            "gfnff",
+        }
+        rdkit_methods = {"uff", "mmff94", "mmff94s"}
+        settings = {
+            "openmm": {"antechamber": gaff_forcefields, "smirnoff": openff_forcefields},
+            "torchani": {None: ani_methods},
+            "xtb": {None: xtb_methods},
+            "rdkit": {None: rdkit_methods},
+            "psi4": {},
+        }
+
+        if program.lower() != "psi4":
+            # we need to make sure it is valid in the above list
+            program_settings = settings.get(program.lower(), None)
+            if program_settings is None:
+                raise QCSpecificationError(
+                    f"The program {program.lower()} is not supported please use one of the following {settings.keys()}"
+                )
+            allowed_methods = program_settings.get(basis, None)
+            if allowed_methods is None:
+                raise QCSpecificationError(
+                    f"The Basis {basis} is not supported for the program {program}, chose from {program_settings.keys()}"
+                )
+            # now we need to check the methods
+            # strip the offxml if present
+            method = method.split(".offxml")[0].lower()
+            if method not in allowed_methods:
+                raise QCSpecificationError(
+                    f"The method {method} is not supported for the program {program} with basis {basis}, please chose from {allowed_methods}"
+                )
+        super().__init__(
+            method=method,
+            basis=basis,
+            program=program.lower(),
+            spec_name=spec_name,
+            spec_description=spec_description,
+            store_wavefunction=store_wavefunction,
+        )
+
     def dict(
         self,
         *,
-        include: Union['AbstractSetIntStr', 'MappingIntStrAny'] = None,
-        exclude: Union['AbstractSetIntStr', 'MappingIntStrAny'] = None,
+        include: Union["AbstractSetIntStr", "MappingIntStrAny"] = None,
+        exclude: Union["AbstractSetIntStr", "MappingIntStrAny"] = None,
         by_alias: bool = False,
         skip_defaults: bool = None,
         exclude_unset: bool = False,
         exclude_defaults: bool = False,
         exclude_none: bool = False,
-    ) -> 'DictStrAny':
+    ) -> "DictStrAny":
 
-        data = super().dict(exclude={"store_wavefunction"})
-        data["store_wavefunction"] = self.store_wavefunction.value
+        data = super().dict(
+            include=include,
+            exclude=exclude,
+            by_alias=by_alias,
+            skip_defaults=skip_defaults,
+            exclude_defaults=exclude_defaults,
+            exclude_unset=exclude_unset,
+            exclude_none=exclude_none,
+        )
+        if "store_wavefunction" in data:
+            data["store_wavefunction"] = self.store_wavefunction.value
         return data
+
+
+class QCSpecificationHandler(BaseModel):
+    """
+    A mixin class for handling the QCSpecification
+    """
+
+    qc_specifications: Dict[str, QCSpec] = {"default": QCSpec()}
+
+    def clear_qcspecs(self) -> None:
+        """
+        Clear out any current QCSpecs.
+        """
+        self.qc_specifications = {}
+
+    def remove_qcspec(self, spec_name: str) -> None:
+        """
+        Remove a QCSpec from the dataset.
+
+        Parameters:
+            spec_name: The name of the spec that should be removed.
+
+        Note:
+            The QCSpec settings are not mutable and so they must be removed and a new one added to ensure they are fully validated.
+        """
+        if spec_name in self.qc_specifications.keys():
+            del self.qc_specifications[spec_name]
+
+    @property
+    def n_qc_specs(self) -> int:
+        """
+        Return the number of QCSpecs on this dataset.
+        """
+        return len(self.qc_specifications)
+
+    def _check_qc_specs(self) -> None:
+        if self.n_qc_specs == 0:
+            raise QCSpecificationError(
+                f"There are no QCSpecifications for this dataset please add some using `add_qc_spec`"
+            )
+
+    def add_qc_spec(
+        self,
+        method: str,
+        basis: Optional[str],
+        program: str,
+        spec_name: str,
+        spec_description: str,
+        store_wavefunction: str = "none",
+        overwrite: bool = False,
+    ) -> None:
+        """
+        Add a new qcspecification to the factory which will be applied to the dataset.
+
+        Parameters:
+            method: The name of the method to use eg B3LYP-D3BJ
+            basis: The name of the basis to use can also be `None`
+            program: The name of the program to execute the computation
+            spec_name: The name the spec should be stored under
+            spec_description: The description of the spec
+            store_wavefunction: what parts of the wavefunction that should be saved
+            overwrite: If there is a spec under this name already overwrite it
+        """
+        spec = QCSpec(
+            method=method,
+            basis=basis,
+            program=program,
+            spec_name=spec_name,
+            spec_description=spec_description,
+            store_wavefunction=store_wavefunction,
+        )
+
+        if spec_name not in self.qc_specifications:
+            self.qc_specifications[spec.spec_name] = spec
+        elif overwrite:
+            self.qc_specifications[spec.spec_name] = spec
+        else:
+            raise QCSpecificationError(
+                f"A specification is already stored under {spec_name} to replace it set `overwrite=True`."
+            )
 
 
 def order_torsion(torsion: Tuple[int, int, int, int]) -> Tuple[int, int, int, int]:

--- a/qcsubmit/data/settings.json
+++ b/qcsubmit/data/settings.json
@@ -2,7 +2,7 @@
   "method": "loaded method",
   "basis": "loaded basis",
   "program": "loaded program",
-  "maxiter": 200,
+  "maxiter": 400,
   "driver": "gradient",
   "scf_properties": [
     "dipole",
@@ -12,7 +12,7 @@
   "spec_name": "default",
   "spec_description": "Standard OpenFF optimization quantum chemistry specification.",
   "client": "public",
-  "priority": "normal",
+  "priority": "super_high",
   "compute_tag": "loaded tag",
   "workflow": {}
 }

--- a/qcsubmit/data/settings.yaml
+++ b/qcsubmit/data/settings.yaml
@@ -1,9 +1,9 @@
 basis: loaded basis
 client: public
 driver: gradient
-maxiter: 200
+maxiter: 400
 method: loaded method
-priority: normal
+priority: super_high
 program: loaded program
 scf_properties:
 - dipole

--- a/qcsubmit/data/settings_with_workflow.json
+++ b/qcsubmit/data/settings_with_workflow.json
@@ -2,7 +2,7 @@
   "method": "loaded method",
   "basis": "loaded basis",
   "program": "loaded program",
-  "maxiter": 200,
+  "maxiter": 400,
   "driver": "gradient",
   "scf_properties": [
     "dipole",
@@ -12,7 +12,7 @@
   "spec_name": "default",
   "spec_description": "Standard OpenFF optimization quantum chemistry specification.",
   "client": "public",
-  "priority": "normal",
+  "priority": "super_high",
   "compute_tag": "loaded tag",
   "workflow": {
     "StandardConformerGenerator": {

--- a/qcsubmit/data/settings_with_workflow.yaml
+++ b/qcsubmit/data/settings_with_workflow.yaml
@@ -1,9 +1,9 @@
 basis: loaded basis
 client: public
 driver: gradient
-maxiter: 200
+maxiter: 400
 method: loaded method
-priority: normal
+priority: super_high
 program: loaded program
 scf_properties:
 - dipole

--- a/qcsubmit/datasets.py
+++ b/qcsubmit/datasets.py
@@ -26,7 +26,6 @@ from .exceptions import (
     DatasetInputError,
     DihedralConnectionError,
     MissingBasisCoverageError,
-    QCSpecificationError,
     UnsupportedFiletypeError,
 )
 from .procedures import GeometricProcedure
@@ -759,7 +758,7 @@ class BasicDataset(IndexCleaner, ClientHandler, QCSpecificationHandler, DatasetC
             for spec_name, report in basis_report.items():
                 if report:
                     raise MissingBasisCoverageError(
-                        f"The following elements: {report} are not covered by the selected basis : {self.qc_specifications[spec_name].basis}"
+                        f"The following elements: {report} are not covered by the selected basis : {self.qc_specifications[spec_name].basis} and method : {self.qc_specifications[spec_name].method}"
                     )
 
         else:
@@ -855,8 +854,6 @@ class BasicDataset(IndexCleaner, ClientHandler, QCSpecificationHandler, DatasetC
         collection.save()
 
         # submit the calculations for each spec
-        # only one spec is stored per program so we have to find the name
-        program_spec = collection.list_keywords()
         responses = {}
         for spec in self.qc_specifications.values():
             response = collection.compute(

--- a/qcsubmit/datasets.py
+++ b/qcsubmit/datasets.py
@@ -8,6 +8,8 @@ import qcportal as ptl
 from openforcefield import topology as off
 from pydantic import PositiveInt, constr, validator
 from qcfractal.interface import FractalClient
+from qcfractal.interface.collections.collection_utils import composition_planner
+from qcfractal.interface.models import ComputeResponse
 from qcportal.models.common_models import DriverEnum, QCSpecification
 from simtk import unit
 
@@ -853,21 +855,23 @@ class BasicDataset(IndexCleaner, ClientHandler, QCSpecificationHandler, DatasetC
         # save the final dataset
         collection.save()
 
-        # submit the calculations for each spec
-        responses = {}
-        for spec in self.qc_specifications.values():
-            response = collection.compute(
-                method=spec.method,
-                basis=spec.basis,
-                keywords=spec.spec_name,
-                program=spec.program,
-                tag=self.compute_tag,
-                priority=self.priority,
-            )
-
-            collection.save()
-            # save the response per submission
-            responses[spec.spec_name] = response
+        # submit the calculations for each spec using the workaround
+        # TODO replace this call when qcfractal is updated.
+        responses = self._dataset_add_compute(collection=collection)
+        collection.save()
+        # for spec in self.qc_specifications.values():
+        #     response = collection.compute(
+        #         method=spec.method,
+        #         basis=spec.basis,
+        #         keywords=spec.spec_name,
+        #         program=spec.program,
+        #         tag=self.compute_tag,
+        #         priority=self.priority,
+        #     )
+        #
+        #     collection.save()
+        #     # save the response per submission
+        #     responses[spec.spec_name] = response
 
         return responses
         # result = BasicResult()
@@ -876,6 +880,71 @@ class BasicDataset(IndexCleaner, ClientHandler, QCSpecificationHandler, DatasetC
         #     pass
         #
         # return result
+
+    def _dataset_add_compute(
+        self, collection: ptl.collections.Dataset
+    ) -> Dict[str, ComputeResponse]:
+        """
+        Workaround to add compute to a basic dataset with wavefunction protocols until qcfractal is updated.
+        """
+        # only allowed on normal datasets
+        if self.dataset_type == "DataSet":
+            # get the molecule ids
+            molecule_idx = [e.molecule_id for e in collection.data.records]
+            responses = {}
+            for spec in self.qc_specifications.values():
+                compute_keys = {
+                    "program": spec.program,
+                    "method": spec.method,
+                    "basis": spec.basis,
+                    "keywords": spec.spec_name,
+                }
+                name, dbkeys, history = collection._default_parameters(
+                    compute_keys["program"],
+                    compute_keys["method"],
+                    compute_keys["basis"],
+                    compute_keys["keywords"],
+                    stoich=compute_keys.get("stoich", None),
+                )
+
+                collection._check_client()
+                collection._check_state()
+
+                umols = list(set(molecule_idx))
+
+                ids = []
+                submitted = []
+                existing = []
+
+                for compute_set in composition_planner(**dbkeys):
+
+                    for i in range(0, len(umols), collection.client.query_limit):
+                        chunk_mols = umols[i : i + collection.client.query_limit]
+                        ret = collection.client.add_compute(
+                            **compute_set,
+                            molecule=chunk_mols,
+                            tag=self.compute_tag,
+                            priority=self.priority,
+                            protocols={"wavefunction": spec.store_wavefunction.value},
+                        )
+
+                        ids.extend(ret.ids)
+                        submitted.extend(ret.submitted)
+                        existing.extend(ret.existing)
+
+                    qhistory = history.copy()
+                    qhistory["program"] = compute_set["program"]
+                    qhistory["method"] = compute_set["method"]
+                    qhistory["basis"] = compute_set["basis"]
+                    collection._add_history(**qhistory)
+
+                responses[spec.spec_name] = ComputeResponse(
+                    ids=ids, submitted=submitted, existing=existing
+                )
+
+            # save and return
+            collection.save()
+            return responses
 
     def export_dataset(self, file_name: str) -> None:
         """

--- a/qcsubmit/exceptions.py
+++ b/qcsubmit/exceptions.py
@@ -133,3 +133,12 @@ class DatasetCombinationError(QCSubmitException):
 
     error_type = "dataset combination error"
     header = "Dataset Combination Error"
+
+
+class QCSpecificationError(QCSubmitException):
+    """
+    The QCSpecification combination of method basis and program is not valid.
+    """
+
+    error_type = "qcspecification error"
+    header = "QCSpecification Error"

--- a/qcsubmit/factories.py
+++ b/qcsubmit/factories.py
@@ -140,6 +140,14 @@ class BasicDatasetFactory(ClientHandler, QCSpecificationHandler, BaseModel):
             "qcsubmit": qcsubmit.__version__,
             "openforcefield": openforcefield.__version__,
         }
+        try:
+            import openeye
+
+            provenance["openeye"] = openeye.__version__
+        except ImportError:
+            import rdkit
+
+            provenance["rdkit"] = rdkit.__version__
 
         return provenance
 

--- a/qcsubmit/factories.py
+++ b/qcsubmit/factories.py
@@ -2,12 +2,12 @@ import os
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from openforcefield import topology as off
-from pydantic import BaseModel, PositiveInt, constr, validator
+from pydantic import BaseModel, PositiveInt, validator
 from qcportal import FractalClient
 from qcportal.models.common_models import DriverEnum
 
 from . import workflow_components
-from .common_structures import ClientHandler, Metadata, QCSpec
+from .common_structures import ClientHandler, Metadata, QCSpecificationHandler
 from .datasets import (
     BasicDataset,
     ComponentResult,
@@ -28,7 +28,7 @@ from .serializers import deserialize, serialize
 from .validators import scf_property_validator
 
 
-class BasicDatasetFactory(ClientHandler, BaseModel):
+class BasicDatasetFactory(ClientHandler, QCSpecificationHandler, BaseModel):
     """
     Basic dataset generator factory used to build work flows using workflow components before executing them to generate
     a dataset.
@@ -52,7 +52,6 @@ class BasicDatasetFactory(ClientHandler, BaseModel):
         workflow: A dictionary which holds the workflow components to be executed in the set order.
     """
 
-    qc_specifications: Dict[str, QCSpec] = {"default": QCSpec()}
     maxiter: PositiveInt = 200
     driver: DriverEnum = DriverEnum.energy
     scf_properties: List[str] = [
@@ -79,12 +78,6 @@ class BasicDatasetFactory(ClientHandler, BaseModel):
         validate_assignment: bool = True
         arbitrary_types_allowed: bool = True
         title: str = "QCFractalDatasetFactory"
-
-    def add_qc_spec(self, method: str, basis: str, program: str, spec_name: str, spec_description: str, wavefunction_options: str = "none") -> None:
-        """
-        Add a new qcspecification to the factory which will be applied to the dataset.
-        """
-
 
     def add_scf_property(self, scf_property: str) -> None:
         """
@@ -553,12 +546,8 @@ class BasicDatasetFactory(ClientHandler, BaseModel):
             attributes = self.create_cmiles_metadata(molecule=order_mol)
             attributes["provenance"] = self.provenance()
 
-            # if we are using MM we should put the cmiles in the extras
+            # always put the cmiles in the extras from what we have just calculated to ensure correct order
             extras = molecule.properties.get("extras", {})
-            if self.program in self._mm_programs:
-                extras[
-                    "canonical_isomeric_explicit_hydrogen_mapped_smiles"
-                ] = attributes["canonical_isomeric_explicit_hydrogen_mapped_smiles"]
 
             keywords = molecule.properties.get("keywords", None)
 
@@ -849,10 +838,6 @@ class TorsiondriveDatasetFactory(OptimizationDatasetFactory):
 
             # make the general attributes
             attributes = self.create_cmiles_metadata(molecule=molecule)
-            if self.program in self._mm_programs:
-                extras[
-                    "canonical_isomeric_explicit_hydrogen_mapped_smiles"
-                ] = attributes["canonical_isomeric_explicit_hydrogen_mapped_smiles"]
 
             # now check for the dihedrals
             if "dihedrals" in molecule.properties:

--- a/qcsubmit/factories.py
+++ b/qcsubmit/factories.py
@@ -7,7 +7,7 @@ from qcportal import FractalClient
 from qcportal.models.common_models import DriverEnum
 
 from . import workflow_components
-from .common_structures import ClientHandler, Metadata
+from .common_structures import ClientHandler, Metadata, QCSpec
 from .datasets import (
     BasicDataset,
     ComponentResult,
@@ -52,9 +52,7 @@ class BasicDatasetFactory(ClientHandler, BaseModel):
         workflow: A dictionary which holds the workflow components to be executed in the set order.
     """
 
-    method: constr(strip_whitespace=True) = "B3LYP-D3BJ"
-    basis: Optional[constr(strip_whitespace=True)] = "DZVP"
-    program: str = "psi4"
+    qc_specifications: Dict[str, QCSpec] = {"default": QCSpec()}
     maxiter: PositiveInt = 200
     driver: DriverEnum = DriverEnum.energy
     scf_properties: List[str] = [
@@ -63,8 +61,6 @@ class BasicDatasetFactory(ClientHandler, BaseModel):
         "wiberg_lowdin_indices",
         "mayer_indices",
     ]
-    spec_name: str = "default"
-    spec_description: str = "Standard OpenFF optimization quantum chemistry specification."
     priority: str = "normal"
     dataset_tags: List[str] = ["openff"]
     compute_tag: str = "openff"
@@ -83,6 +79,12 @@ class BasicDatasetFactory(ClientHandler, BaseModel):
         validate_assignment: bool = True
         arbitrary_types_allowed: bool = True
         title: str = "QCFractalDatasetFactory"
+
+    def add_qc_spec(self, method: str, basis: str, program: str, spec_name: str, spec_description: str, wavefunction_options: str = "none") -> None:
+        """
+        Add a new qcspecification to the factory which will be applied to the dataset.
+        """
+
 
     def add_scf_property(self, scf_property: str) -> None:
         """

--- a/qcsubmit/results.py
+++ b/qcsubmit/results.py
@@ -971,6 +971,15 @@ class OptimizationCollectionResult(BasicCollectionResult):
             dataset_tagline=tagline,
             driver=driver,
         )
+        # now we need to add the QC_spec
+        dataset.clear_qcspecs()
+        dataset.add_qc_spec(
+            method=self.method,
+            basis=self.basis,
+            program=self.program,
+            spec_name=self.spec_name,
+            spec_description=self.spec_description,
+        )
 
         for common_index, entries in self.collection.items():
             for result in entries.entries:
@@ -1027,6 +1036,15 @@ class OptimizationCollectionResult(BasicCollectionResult):
             dataset_name=dataset_name,
             description=description,
             dataset_tagline=tagline,
+        )
+        # now we need to add the QC_spec
+        dataset.clear_qcspecs()
+        dataset.add_qc_spec(
+            method=self.method,
+            basis=self.basis,
+            program=self.program,
+            spec_name=self.spec_name,
+            spec_description=self.spec_description,
         )
 
         # now we need to add the molecules
@@ -1475,6 +1493,15 @@ class TorsionDriveCollectionResult(OptimizationCollectionResult):
             description=description,
             dataset_tagline=tagline,
         )
+        # now we need to add the QC_spec
+        dataset.clear_qcspecs()
+        dataset.add_qc_spec(
+            method=self.method,
+            basis=self.basis,
+            program=self.program,
+            spec_name=self.spec_name,
+            spec_description=self.spec_description,
+        )
         # now we need to fill the dataset
         for result in self.collection.values():
             attributes = result.attributes
@@ -1536,6 +1563,15 @@ class TorsionDriveCollectionResult(OptimizationCollectionResult):
             dataset_tagline=tagline,
             driver=driver,
         )
+        # now we need to add the QC_spec
+        dataset.clear_qcspecs()
+        dataset.add_qc_spec(
+            method=self.method,
+            basis=self.basis,
+            program=self.program,
+            spec_name=self.spec_name,
+            spec_description=self.spec_description,
+        )
 
         # now we need to fill the dataset
         for result in self.collection.values():
@@ -1591,6 +1627,15 @@ class TorsionDriveCollectionResult(OptimizationCollectionResult):
             dataset_name=dataset_name,
             description=description,
             dataset_tagline=tagline,
+        )
+        # now we need to add the QC_spec
+        dataset.clear_qcspecs()
+        dataset.add_qc_spec(
+            method=self.method,
+            basis=self.basis,
+            program=self.program,
+            spec_name=self.spec_name,
+            spec_description=self.spec_description,
         )
 
         # now we need to fill in the dataset data

--- a/qcsubmit/tests/test_datasets.py
+++ b/qcsubmit/tests/test_datasets.py
@@ -31,7 +31,11 @@ from qcsubmit.exceptions import (
 )
 from qcsubmit.factories import BasicDatasetFactory
 from qcsubmit.testing import temp_directory
-from qcsubmit.utils import condense_molecules, get_data, update_specification_and_metadata
+from qcsubmit.utils import (
+    condense_molecules,
+    get_data,
+    update_specification_and_metadata,
+)
 
 
 def duplicated_molecules(include_conformers: bool = True, duplicates: int = 2):

--- a/qcsubmit/tests/test_factories.py
+++ b/qcsubmit/tests/test_factories.py
@@ -213,7 +213,7 @@ def test_exporting_settings_no_workflow(file_type, factory_type):
     with temp_directory():
         factory = factory_type()
 
-        changed_attrs = {"method": "test method", "basis": "test basis", "program": "test program", "compute_tag": "test tag"}
+        changed_attrs = {"maxiter": 400, "priority":  "super_high", "compute_tag": "test tag"}
         for attr, value in changed_attrs.items():
             setattr(factory, attr, value)
 
@@ -224,7 +224,7 @@ def test_exporting_settings_no_workflow(file_type, factory_type):
         with open(file_name) as f:
             data = f.read()
             for value in changed_attrs.values():
-                assert value in data
+                assert str(value) in data
 
 
 @pytest.mark.parametrize("file_type", [pytest.param("json", id="json"), pytest.param("yaml", id="yaml")])
@@ -241,7 +241,7 @@ def test_exporting_settings_workflow(file_type, factory_type):
     with temp_directory():
 
         factory = factory_type()
-        changed_attrs = {"method": "test method", "basis": "test basis", "program": "test program", "compute_tag": "test tag"}
+        changed_attrs = {"maxiter": 400, "priority":  "super_high", "compute_tag": "test tag"}
         for attr, value in changed_attrs.items():
             setattr(factory, attr, value)
 
@@ -276,9 +276,8 @@ def test_importing_settings_no_workflow(file_type, factory_type):
     factory.import_settings(get_data(file_name))
 
     changed_attrs = {
-        "method": "loaded method",
-        "basis": "loaded basis",
-        "program": "loaded program",
+        "maxiter": 400,
+        "priority": "super_high",
         "compute_tag": "loaded tag",
     }
     for attr, value in changed_attrs.items():
@@ -302,9 +301,8 @@ def test_importing_settings_workflow(file_type, factory_type):
     factory.import_settings(get_data(file_name))
 
     changed_attrs = {
-        "method": "loaded method",
-        "basis": "loaded basis",
-        "program": "loaded program",
+        "maxiter": 400,
+        "priority": "super_high",
         "compute_tag": "loaded tag",
     }
     for attr, value in changed_attrs.items():
@@ -523,8 +521,9 @@ def test_create_dataset(factory_dataset_type):
     mols = Molecule.from_file(get_data("tautomers_small.smi"), "smi", allow_undefined_stereo=True)
 
     # set some settings
-    changed_attrs = {"method": "test method", "basis": "test basis", "program": "test program", "compute_tag": "test tag",
-                     "dataset_tags": ["openff", "test"]}
+    changed_attrs = {"compute_tag": "test tag",
+                     "dataset_tags": ["openff", "test"],
+                     "maxiter": 400}
     for attr, value in changed_attrs.items():
         setattr(factory, attr, value)
 

--- a/qcsubmit/tests/test_serializers.py
+++ b/qcsubmit/tests/test_serializers.py
@@ -1,0 +1,86 @@
+"""
+Test the serializer factory
+"""
+import pytest
+
+from qcsubmit.exceptions import UnsupportedFiletypeError
+from qcsubmit.serializers import (
+    JsonDeSerializer,
+    JsonSerializer,
+    YamlDeSerializer,
+    YamlSerializer,
+    deserialize,
+    get_deserializer,
+    get_serializer,
+    register_deserializer,
+    register_serializer,
+    unregister_deserializer,
+    unregister_serializer,
+)
+
+
+@pytest.mark.parametrize("serializer_type", [
+    pytest.param(("JSON", JsonSerializer), id="Json"),
+    pytest.param(("YAML", YamlSerializer), id="Yaml")
+])
+def test_register_again(serializer_type):
+    """
+    Test adding another serializer
+    """
+
+    with pytest.raises(ValueError):
+        register_serializer(*serializer_type)
+
+
+@pytest.mark.parametrize("deserializer_type", [
+    pytest.param(("JSON", JsonDeSerializer), id="Json"),
+    pytest.param(("YAML", YamlDeSerializer), id="Yaml")
+])
+def test_register_again_deserializer(deserializer_type):
+    """
+    Test registering a deserializer again.
+    """
+
+    with pytest.raises(ValueError):
+        register_deserializer(*deserializer_type)
+
+
+def test_get_serializer_error():
+    """
+    Test getting a serializer which is not registered.
+    """
+    with pytest.raises(UnsupportedFiletypeError):
+        get_serializer("bson")
+
+
+def test_get_deserializer_error():
+    """
+    Test getting a deserialzier which is not registered.
+    """
+    with pytest.raises(UnsupportedFiletypeError):
+        get_deserializer("bson")
+
+
+def test_deregister_serializer_error():
+    """
+    Test removing a serializer that is not registered.
+    """
+    with pytest.raises(KeyError):
+        unregister_serializer("bson")
+
+
+def test_deregister_deserializer_error():
+    """
+    Test removing a serializer that is not registered.
+    """
+    with pytest.raises(KeyError):
+        unregister_deserializer("bson")
+
+
+def test_deserializer_error():
+    """
+    Test deserialize a missing file.
+    """
+
+    with pytest.raises(RuntimeError):
+        deserialize("missing_file.json")

--- a/qcsubmit/tests/test_submissions.py
+++ b/qcsubmit/tests/test_submissions.py
@@ -21,23 +21,27 @@ from qcsubmit.utils import get_data
 
 
 @pytest.mark.parametrize("specification", [
-    pytest.param(("hf", "3-21g", "psi4", "energy"), id="PSI4 hf 3-21g energy"),
-    pytest.param(("openff-1.0.0", "smirnoff", "openmm", "energy"), id="SMIRNOFF openff-1.0.0 energy"),
-    pytest.param(("uff", None, "rdkit", "gradient"), id="RDKit UFF gradient")
+    pytest.param(({"method": "hf", "basis": "3-21g", "program": "psi4"}, "energy"), id="PSI4 hf 3-21g energy"),
+    pytest.param(({"method": "openff-1.0.0", "basis": "smirnoff", "program": "openmm"}, "energy"), id="SMIRNOFF openff-1.0.0 energy"),
+    pytest.param(({"method": "uff", "basis": None, "program": "rdkit"}, "gradient"), id="RDKit UFF gradient")
 ])
-def test_basic_submissions(fractal_compute_server, specification):
+def test_basic_submissions_single_spec(fractal_compute_server, specification):
     """Test submitting a basic dataset to a snowflake server."""
 
     client = FractalClient(fractal_compute_server)
 
-    method, basis, program, driver = specification
+    qc_spec, driver = specification
 
+    program = qc_spec["program"]
     if not has_program(program):
         pytest.skip(f"Program '{program}' not found.")
 
     molecules = Molecule.from_file(get_data("butane_conformers.pdb"), "pdb")
 
-    factory = BasicDatasetFactory(method=method, basis=basis, program=program, driver=driver)
+    factory = BasicDatasetFactory(driver=driver)
+    factory.add_qc_spec(**qc_spec, spec_name="default",
+                        spec_description="testing the single points",
+                        overwrite=True)
 
     dataset = factory.create_dataset(dataset_name=f"Test single points info {program}, {driver}",
                                      molecules=molecules,
@@ -76,46 +80,121 @@ def test_basic_submissions(fractal_compute_server, specification):
     # get the last ran spec
     for specification in ds.data.history:
         driver, program, method, basis, spec_name = specification
-        if spec_name == dataset.spec_name:
-            assert driver == dataset.driver
-            assert program == dataset.program
-            assert method == dataset.method
-            assert basis == dataset.basis
-            break
+        spec = dataset.qc_specifications[spec_name]
+        assert driver == dataset.driver
+        assert program == spec.program
+        assert method == spec.method
+        assert basis == spec.basis
+        break
     else:
         raise RuntimeError(f"The requested compute was not found in the history {ds.data.history}")
 
+    for spec in dataset.qc_specifications.values():
+        query = ds.get_records(
+            method=spec.method,
+            basis=spec.basis,
+            program=spec.program,
+        )
+        for index in query.index:
+            result = query.loc[index].record
+            assert result.status.value.upper() == "COMPLETE"
+            assert result.error is None
+            assert result.return_result is not None
 
-    query = ds.get_records(
-        method=dataset.method,
-        basis=dataset.basis,
-        program=dataset.program,
-    )
-    for index in query.index:
-        result = query.loc[index].record
-        assert result.status.value.upper() == "COMPLETE"
-        assert result.error is None
-        assert result.return_result is not None
+
+def test_basic_submissions_multiple_spec(fractal_compute_server):
+    """Test submitting a basic dataset to a snowflake server with multiple qcspecs."""
+
+    client = FractalClient(fractal_compute_server)
+
+    qc_specs = [{"method": "openff-1.0.0", "basis": "smirnoff", "program": "openmm", "spec_name": "openff"},
+                {"method": "gaff-2.11", "basis": "antechamber", "program": "openmm", "spec_name": "gaff"}]
+
+    molecules = Molecule.from_file(get_data("butane_conformers.pdb"), "pdb")
+
+    factory = BasicDatasetFactory(driver="energy")
+    factory.clear_qcspecs()
+    for spec in qc_specs:
+        factory.add_qc_spec(**spec,
+                            spec_description="testing the single points"
+                            )
+
+    dataset = factory.create_dataset(dataset_name=f"Test single points info openmm, energy",
+                                     molecules=molecules,
+                                     description="Test basics dataset",
+                                     tagline="Testing single point datasets",
+                                     )
+
+    with pytest.raises(DatasetInputError):
+        dataset.submit(client=client, await_result=False)
+
+    # now add a mock url so we can submit the data
+    dataset.metadata.long_description_url = "https://test.org"
+
+    # now submit again
+    dataset.submit(client=client, await_result=False)
+
+    fractal_compute_server.await_results()
+
+    # make sure of the results are complete
+    ds = client.get_collection("Dataset", dataset.dataset_name)
+
+    # check the metadata
+    meta = Metadata(**ds.data.metadata)
+    assert meta == dataset.metadata
+
+    assert ds.data.description == dataset.description
+    assert ds.data.tagline == dataset.dataset_tagline
+    assert ds.data.tags == dataset.dataset_tags
+
+    # check the provenance
+    assert dataset.provenance == ds.data.provenance
+
+    # check the qc spec
+    assert ds.data.default_driver == dataset.driver
+
+    # get the last ran spec
+    for specification in ds.data.history:
+        print(specification)
+        driver, program, method, basis, spec_name = specification
+        spec = dataset.qc_specifications[spec_name]
+        assert driver == dataset.driver
+        assert program == spec.program
+        assert method == spec.method
+        assert basis == spec.basis
+
+    for spec in dataset.qc_specifications.values():
+        query = ds.get_records(
+            method=spec.method,
+            basis=spec.basis,
+            program=spec.program,
+        )
+        for index in query.index:
+            result = query.loc[index].record
+            assert result.status.value.upper() == "COMPLETE"
+            assert result.error is None
+            assert result.return_result is not None
 
 
 @pytest.mark.parametrize("specification", [
-    pytest.param(("hf", "3-21g", "psi4", "gradient"), id="PSI4 hf 3-21g gradient"),
-    pytest.param(("openff_unconstrained-1.0.0", "smirnoff", "openmm", "gradient"), id="SMIRNOFF openff_unconstrained-1.0.0 gradient"),
-    pytest.param(("uff", None, "rdkit", "gradient"), id="RDKit UFF gradient")
+    pytest.param(({"method": "hf", "basis": "3-21g", "program": "psi4"}, "gradient"), id="PSI4 hf 3-21g gradient"),
+    pytest.param(({"method": "openff_unconstrained-1.0.0", "basis": "smirnoff", "program": "openmm"}, "gradient"), id="SMIRNOFF openff_unconstrained-1.0.0 gradient"),
+    pytest.param(({"method": "uff", "basis": None, "program": "rdkit"}, "gradient"), id="RDKit UFF gradient")
 ])
 def test_optimization_submissions(fractal_compute_server, specification):
     """Test submitting an Optimization dataset to a snowflake server."""
 
     client = FractalClient(fractal_compute_server)
 
-    method, basis, program, driver = specification
-
+    qc_spec, driver = specification
+    program = qc_spec["program"]
     if not has_program(program):
         pytest.skip(f"Program '{program}' not found.")
 
     molecules = Molecule.from_file(get_data("butane_conformers.pdb"), "pdb")
 
-    factory = OptimizationDatasetFactory(method=method, basis=basis, program=program, driver=driver)
+    factory = OptimizationDatasetFactory(driver=driver)
+    factory.add_qc_spec(**qc_spec, spec_name="default", spec_description="test", overwrite=True)
 
     dataset = factory.create_dataset(dataset_name=f"Test optimizations info {program}, {driver}",
                                      molecules=molecules[:2],
@@ -145,38 +224,39 @@ def test_optimization_submissions(fractal_compute_server, specification):
     assert dataset.provenance == ds.data.provenance
 
     # check the qc spec
-    spec = ds.data.specs[dataset.spec_name]
+    for qc_spec in dataset.qc_specifications.values():
+        spec = ds.data.specs[qc_spec.spec_name]
 
-    assert spec.description == dataset.spec_description
-    assert spec.qc_spec.driver == dataset.driver
-    assert spec.qc_spec.method == dataset.method
-    assert spec.qc_spec.basis == dataset.basis
-    assert spec.qc_spec.program == dataset.program
+        assert spec.description == qc_spec.spec_description
+        assert spec.qc_spec.driver == dataset.driver
+        assert spec.qc_spec.method == qc_spec.method
+        assert spec.qc_spec.basis == qc_spec.basis
+        assert spec.qc_spec.program == qc_spec.program
 
-    # check the keywords
-    keywords = client.query_keywords(spec.qc_spec.keywords)[0]
+        # check the keywords
+        keywords = client.query_keywords(spec.qc_spec.keywords)[0]
 
-    assert keywords.values["maxiter"] == dataset.maxiter
-    assert keywords.values["scf_properties"] == dataset.scf_properties
+        assert keywords.values["maxiter"] == dataset.maxiter
+        assert keywords.values["scf_properties"] == dataset.scf_properties
 
-    # query the dataset
-    ds.query(dataset.spec_name)
+        # query the dataset
+        ds.query(qc_spec.spec_name)
 
-    for index in ds.df.index:
-        record = ds.df.loc[index].default
-        assert record.status.value == "COMPLETE"
-        assert record.error is None
-        assert len(record.trajectory) > 1
-        # if we used psi4 make sure the properties were captured
-        if program == "psi4":
-            result = record.get_trajectory()[0]
-            assert "CURRENT DIPOLE X" in result.extras["qcvars"].keys()
-            assert "SCF QUADRUPOLE XX" in result.extras["qcvars"].keys()
+        for index in ds.df.index:
+            record = ds.df.loc[index].default
+            assert record.status.value == "COMPLETE"
+            assert record.error is None
+            assert len(record.trajectory) > 1
+            # if we used psi4 make sure the properties were captured
+            if program == "psi4":
+                result = record.get_trajectory()[0]
+                assert "CURRENT DIPOLE X" in result.extras["qcvars"].keys()
+                assert "SCF QUADRUPOLE XX" in result.extras["qcvars"].keys()
 
 
 @pytest.mark.parametrize("specification", [
-    pytest.param(("openff_unconstrained-1.1.0", "smirnoff", "openmm", "gradient"), id="SMIRNOFF openff_unconstrained-1.0.0 gradient"),
-    pytest.param(("mmff94", None, "rdkit", "gradient"), id="RDKit mmff94 gradient")
+    pytest.param(({"method": "openff_unconstrained-1.1.0", "basis": "smirnoff", "program": "openmm"}, "gradient"), id="SMIRNOFF openff_unconstrained-1.0.0 gradient"),
+    pytest.param(({"method": "mmff94", "basis": None, "program": "rdkit"}, "gradient"), id="RDKit mmff94 gradient")
 ])
 def test_torsiondrive_submissions(fractal_compute_server, specification):
     """
@@ -185,14 +265,15 @@ def test_torsiondrive_submissions(fractal_compute_server, specification):
 
     client = FractalClient(fractal_compute_server)
 
-    method, basis, program, driver = specification
-
+    qc_spec, driver = specification
+    program = qc_spec["program"]
     if not has_program(program):
         pytest.skip(f"Program '{program}' not found.")
 
     molecules = Molecule.from_smiles("CO")
 
-    factory = TorsiondriveDatasetFactory(method=method, basis=basis, program=program, driver=driver)
+    factory = TorsiondriveDatasetFactory(driver=driver)
+    factory.add_qc_spec(**qc_spec, spec_name="default", spec_description="test", overwrite=True)
 
     dataset = factory.create_dataset(dataset_name=f"Test torsiondrives info {program}, {driver}",
                                      molecules=molecules,
@@ -222,26 +303,27 @@ def test_torsiondrive_submissions(fractal_compute_server, specification):
     assert dataset.provenance == ds.data.provenance
 
     # check the qc spec
-    spec = ds.data.specs[dataset.spec_name]
+    for qc_spec in dataset.qc_specifications.values():
+        spec = ds.data.specs[qc_spec.spec_name]
 
-    assert spec.description == dataset.spec_description
-    assert spec.qc_spec.driver == dataset.driver
-    assert spec.qc_spec.method == dataset.method
-    assert spec.qc_spec.basis == dataset.basis
-    assert spec.qc_spec.program == dataset.program
+        assert spec.description == qc_spec.spec_description
+        assert spec.qc_spec.driver == dataset.driver
+        assert spec.qc_spec.method == qc_spec.method
+        assert spec.qc_spec.basis == qc_spec.basis
+        assert spec.qc_spec.program == qc_spec.program
 
-    # check the keywords
-    keywords = client.query_keywords(spec.qc_spec.keywords)[0]
+        # check the keywords
+        keywords = client.query_keywords(spec.qc_spec.keywords)[0]
 
-    assert keywords.values["maxiter"] == dataset.maxiter
-    assert keywords.values["scf_properties"] == dataset.scf_properties
+        assert keywords.values["maxiter"] == dataset.maxiter
+        assert keywords.values["scf_properties"] == dataset.scf_properties
 
-    # query the dataset
-    ds.query(dataset.spec_name)
+        # query the dataset
+        ds.query(qc_spec.spec_name)
 
-    for index in ds.df.index:
-        record = ds.df.loc[index].default
-        # this will take some time so make sure it is running with no error
-        assert record.status.value == "COMPLETE", print(record.dict())
-        assert record.error is None
-        assert len(record.final_energy_dict) == 24
+        for index in ds.df.index:
+            record = ds.df.loc[index].default
+            # this will take some time so make sure it is running with no error
+            assert record.status.value == "COMPLETE", print(record.dict())
+            assert record.error is None
+            assert len(record.final_energy_dict) == 24

--- a/qcsubmit/tests/test_submissions.py
+++ b/qcsubmit/tests/test_submissions.py
@@ -119,7 +119,7 @@ def test_basic_submissions_multiple_spec(fractal_compute_server):
                             spec_description="testing the single points"
                             )
 
-    dataset = factory.create_dataset(dataset_name=f"Test single points info openmm, energy",
+    dataset = factory.create_dataset(dataset_name=f"Test single points multiple specs",
                                      molecules=molecules,
                                      description="Test basics dataset",
                                      tagline="Testing single point datasets",

--- a/qcsubmit/tests/test_submissions.py
+++ b/qcsubmit/tests/test_submissions.py
@@ -250,7 +250,6 @@ def test_basic_submissions_wavefunction(fractal_compute_server):
             assert basis.name.lower() == "sto-3g"
             orbitals = result.get_wavefunction("orbitals_a")
             assert orbitals.shape is not None
-            print(orbitals)
 
 
 @pytest.mark.parametrize("specification", [

--- a/qcsubmit/utils.py
+++ b/qcsubmit/utils.py
@@ -97,7 +97,7 @@ def update_specification_and_metadata(
                 program=program,
                 spec_name=spec,
                 spec_description="basic dataset spec",
-                )
+            )
     else:
         # we have the opt or torsiondrive
         if not dataset.metadata.elements:

--- a/qcsubmit/utils.py
+++ b/qcsubmit/utils.py
@@ -2,7 +2,7 @@ from typing import Dict, List, Union
 
 from openforcefield import topology as off
 
-from qcsubmit.datasets import BasicDataset, TorsiondriveDataset, OptimizationDataset
+from qcsubmit.datasets import BasicDataset, OptimizationDataset, TorsiondriveDataset
 
 
 def get_data(relative_path):


### PR DESCRIPTION
## Description
This allows factories and datasets to handle multiple QC specs which are heavily validated to avoid run time issues and can be submitted simultaneously. We also expand the qc spec to store wavefunction protocols allowing the saving of the wavefunction.

The second major change is that all datasets now have the cmiles stored at the molecule level, this is still hidden in the extras field but should allow running with MM methods in qcengine.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] It is not currently possible to supply the wavefunction protocol to standard datasets we can use a workaround or wait till this [PR](https://github.com/MolSSI/QCFractal/pull/608) is merged. Probably use the workaround and note to update QCSubmit when this is fixed in fractal.


## Status
- [ ] Ready to go