### PR TITLE
Prevent double-adding a stereoisomer in EnumerateStereoisomers

### DIFF
--- a/qcsubmit/workflow_components/__init__.py
+++ b/qcsubmit/workflow_components/__init__.py
@@ -4,6 +4,7 @@ from .filters import (
     CoverageFilter,
     ElementFilter,
     MolecularWeightFilter,
+    RMSDCutoffConformerFilter,
     RotorFilter,
     SmartsFilter,
 )

--- a/qcsubmit/workflow_components/filters.py
+++ b/qcsubmit/workflow_components/filters.py
@@ -2,8 +2,10 @@
 File containing the filters workflow components.
 """
 import re
-import numpy as np
 from typing import Dict, List, Optional, Set, Union
+
+import numpy as np
+from pydantic import validator
 
 from openforcefield.topology import Molecule
 from openforcefield.typing.chemistry.environment import (
@@ -11,8 +13,6 @@ from openforcefield.typing.chemistry.environment import (
     SMIRKSParsingError,
 )
 from openforcefield.typing.engines.smirnoff import ForceField
-from pydantic import validator
-
 from qcsubmit.common_structures import TorsionIndexer
 from qcsubmit.datasets import ComponentResult
 
@@ -459,7 +459,9 @@ class RMSDCutoffConformerFilter(BasicSettings, CustomWorkflowComponent):
 
     # standard components which must be defined
     component_name = __class__
-    component_description = "Generate conformations for the given molecules using a RMSD cutoff"
+    component_description = (
+        "Generate conformations for the given molecules using a RMSD cutoff"
+    )
     component_fail_message = "Conformers could not be generated"
 
     # custom components for this class
@@ -491,8 +493,8 @@ class RMSDCutoffConformerFilter(BasicSettings, CustomWorkflowComponent):
                 for k in range(j + 1, L):
 
                     r = np.linalg.norm(
-                            molecule.conformers[k] - molecule.conformers[j], axis=1
-                            )
+                        molecule.conformers[k] - molecule.conformers[j], axis=1
+                    )
                     rmsd_i = r.mean()
 
                     # Flag this conformer for pruning, and also
@@ -504,12 +506,11 @@ class RMSDCutoffConformerFilter(BasicSettings, CustomWorkflowComponent):
             # hack? how to set conformers explicity if different number than
             # currently stored?
             confs = [
-                    molecule.conformers[j] for j, add_bool in enumerate(uniq) if add_bool
-                    ]
+                molecule.conformers[j] for j, add_bool in enumerate(uniq) if add_bool
+            ]
             molecule._conformers = confs.copy()
 
         return molecule
-
 
     def apply(self, molecules: List[Molecule]) -> ComponentResult:
         """

--- a/qcsubmit/workflow_components/filters.py
+++ b/qcsubmit/workflow_components/filters.py
@@ -458,7 +458,7 @@ class RMSDCutoffConformerFilter(BasicSettings, CustomWorkflowComponent):
     """
 
     # standard components which must be defined
-    component_name = __class__
+    component_name = "RMSDCutoffConformerFilter"
     component_description = (
         "Generate conformations for the given molecules using a RMSD cutoff"
     )
@@ -477,8 +477,9 @@ class RMSDCutoffConformerFilter(BasicSettings, CustomWorkflowComponent):
         # processing.
         uniq: List = list([True] * L)
 
+        rmsd = []
         # This begins the pairwise RMSD pruner
-        if L > 1 and self.rmsd_cutoff > 0.0:
+        if L > 1 and self.rmsd_cutoff >= 0.0:
 
             # The reference conformer for RMSD calculation
             for j in range(L - 1):
@@ -496,6 +497,7 @@ class RMSDCutoffConformerFilter(BasicSettings, CustomWorkflowComponent):
                         molecule.conformers[k] - molecule.conformers[j], axis=1
                     )
                     rmsd_i = r.mean()
+                    rmsd.append(rmsd_i)
 
                     # Flag this conformer for pruning, and also
                     # prevent it from being used as a reference in the
@@ -508,6 +510,14 @@ class RMSDCutoffConformerFilter(BasicSettings, CustomWorkflowComponent):
             confs = [
                 molecule.conformers[j] for j, add_bool in enumerate(uniq) if add_bool
             ]
+
+            # TODO: use a logger
+            # rmsd = np.array(rmsd)
+            # print(
+            #     "Pruned conformers {}/{} min={} mean={} max={}".format(
+            #         len(confs), L, rmsd.min(), rmsd.mean(), rmsd.max()
+            #     )
+            # )
             molecule._conformers = confs.copy()
 
         return molecule
@@ -529,7 +539,7 @@ class RMSDCutoffConformerFilter(BasicSettings, CustomWorkflowComponent):
 
         for molecule in molecules:
             try:
-                molecule = self._prune_conformers(self, molecule)
+                molecule = self._prune_conformers(molecule)
 
             # need to catch more specific exceptions here.
             except Exception:

--- a/qcsubmit/workflow_components/state_enumeration.py
+++ b/qcsubmit/workflow_components/state_enumeration.py
@@ -5,7 +5,6 @@ from typing import List
 
 from openforcefield.topology import Molecule
 from openforcefield.utils.toolkits import OpenEyeToolkitWrapper
-
 from qcsubmit.datasets import ComponentResult
 
 from .base_component import CustomWorkflowComponent, ToolkitValidator
@@ -129,7 +128,7 @@ class EnumerateStereoisomers(ToolkitValidator, CustomWorkflowComponent):
 
                 for isomer in isomers:
                     result.add_molecule(isomer)
-                
+
                 # TODO: add logger
                 # print("Stereoisomers found {} for {}".format(len(isomers), molecule.to_smiles()))
 

--- a/qcsubmit/workflow_components/state_enumeration.py
+++ b/qcsubmit/workflow_components/state_enumeration.py
@@ -96,7 +96,7 @@ class EnumerateStereoisomers(ToolkitValidator, CustomWorkflowComponent):
     undefined_only: bool = False
     max_isomers: int = 20
     rationalise: bool = True
-    include_input: bool = True
+    include_input: bool = False
 
     def apply(self, molecules: List[Molecule]) -> ComponentResult:
         """
@@ -123,7 +123,7 @@ class EnumerateStereoisomers(ToolkitValidator, CustomWorkflowComponent):
                     rationalise=self.rationalise,
                     toolkit_registry=toolkit,
                 )
-                if self.include_input and len(isomers) == 0:
+                if self.include_input or len(isomers) == 0:
                     result.add_molecule(molecule)
 
                 for isomer in isomers:

--- a/qcsubmit/workflow_components/state_enumeration.py
+++ b/qcsubmit/workflow_components/state_enumeration.py
@@ -124,11 +124,14 @@ class EnumerateStereoisomers(ToolkitValidator, CustomWorkflowComponent):
                     rationalise=self.rationalise,
                     toolkit_registry=toolkit,
                 )
-                if self.include_input:
+                if self.include_input and len(isomers) == 0:
                     result.add_molecule(molecule)
 
                 for isomer in isomers:
                     result.add_molecule(isomer)
+                
+                # TODO: add logger
+                # print("Stereoisomers found {} for {}".format(len(isomers), molecule.to_smiles()))
 
             except Exception:
                 self.fail_molecule(molecule=molecule, component_result=result)


### PR DESCRIPTION
## Description
Fixes #38. It appears that we should only add the original molecule if either 1. no stereoisomers are found or 2. If the setting is explicitly set to True. This PR changes the default setting of `include_input` to False.

## Todos
Notable points that this PR has either accomplished or will accomplish.
- [x] Fixes #38

## Status
- [x] Ready to go