### PR TITLE
Deduplication rework

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -8,7 +8,6 @@ coverage:
       default:
         threshold: 50%
 comment:
-  after_n_builds: 6
   layout: "header"
   require_changes: false
   branches: null

--- a/codecov.yml
+++ b/codecov.yml
@@ -8,6 +8,7 @@ coverage:
       default:
         threshold: 50%
 comment:
+  after_n_builds: 6
   layout: "header"
   require_changes: false
   branches: null

--- a/qcsubmit/datasets.py
+++ b/qcsubmit/datasets.py
@@ -1,11 +1,11 @@
 import json
 import os
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
-import tqdm
 
 import numpy as np
 import qcelemental as qcel
 import qcportal as ptl
+import tqdm
 from openforcefield import topology as off
 from pydantic import PositiveInt, constr, validator
 from qcfractal.interface import FractalClient
@@ -118,7 +118,13 @@ class ComponentResult:
 
         # now lets process the molecules and add them to the class
         if molecules is not None:
-            for molecule in tqdm.tqdm(molecules, total=len(molecules), ncols=80, desc="Deduplication", disable=not verbose):
+            for molecule in tqdm.tqdm(
+                molecules,
+                total=len(molecules),
+                ncols=80,
+                desc="Deduplication",
+                disable=not verbose,
+            ):
                 self.add_molecule(molecule)
 
     @property
@@ -151,7 +157,9 @@ class ComponentResult:
              The number of conformers stored in the molecules.
         """
 
-        conformers = sum([molecule.n_conformers for molecule in self._molecules.values()])
+        conformers = sum(
+            [molecule.n_conformers for molecule in self._molecules.values()]
+        )
         return conformers
 
     @property

--- a/qcsubmit/tests/test_datasets.py
+++ b/qcsubmit/tests/test_datasets.py
@@ -212,6 +212,18 @@ def test_componentresult_deduplication_diff_coords(duplicates):
                     assert molecule.conformers[i].tolist() != molecule.conformers[j].tolist()
 
 
+def test_componentresult_remove_molecule():
+    """
+    Test removing a molecule not in a dataset.
+    """
+    result = ComponentResult(component_name="Test deduplication", component_description={},
+                             component_provenance={})
+    methanol = Molecule.from_file(get_data("methanol.sdf"), "sdf")
+    result.filter_molecule(molecule=methanol)
+
+    assert methanol in result.filtered
+    
+
 def test_componentresult_deduplication_torsions_same_bond_same_coords():
     """
     Make sure that the same rotatable bond is not highlighted more than once when deduplicating molecules.

--- a/qcsubmit/tests/test_datasets.py
+++ b/qcsubmit/tests/test_datasets.py
@@ -222,7 +222,7 @@ def test_componentresult_remove_molecule():
     result.filter_molecule(molecule=methanol)
 
     assert methanol in result.filtered
-    
+
 
 def test_componentresult_deduplication_torsions_same_bond_same_coords():
     """

--- a/qcsubmit/tests/test_workflow_components.py
+++ b/qcsubmit/tests/test_workflow_components.py
@@ -658,4 +658,4 @@ def test_environment_filter_apply_none():
 
     result2 = filter.apply(molecules=result.molecules)
 
-    assert len(result2.molecules) != result.molecules
+    assert len(result2.molecules) != len(result.molecules)

--- a/qcsubmit/workflow_components/filters.py
+++ b/qcsubmit/workflow_components/filters.py
@@ -424,7 +424,8 @@ class SmartsFilter(BasicSettings, CustomWorkflowComponent):
 
         if self.allowed_substructures is None:
             # pass all of the molecules
-            result.molecules = molecules
+            for molecule in molecules:
+                result.add_molecule(molecule=molecule)
 
         else:
             for molecule in molecules:


### PR DESCRIPTION
## Description
Provide a brief description of the PR's purpose here.
This PR will speed up the deduplication steps in the workflow by using a dictionary indexed by the non-standard inchikey to store the molecules rather than a list. 
The API to iterate over the passed and filtered molecules is not changed however.
In preparation for the CLI a verbose flag has also been added to the initial deduplication stage which shows progress using tqdm.

Timing data:
On the 1156 molecules in the [AlkEthOH rings set](https://github.com/openforcefield/open-forcefield-data/blob/master/Model-Systems/AlkEthOH_distrib/AlkEthOH_rings.smi) deduplication now takes 1 second compared to ~4mins with the old method.

## Status
- [X] Ready to go