### PR TITLE
Added compression handling to serialization/deserialization

### DIFF
--- a/qcsubmit/compression.py
+++ b/qcsubmit/compression.py
@@ -1,0 +1,70 @@
+"""Decompression utility `anyopen`.
+
+Adapted from `alchemlyb.parsing.util`.
+
+"""
+import os
+import bz2
+import gzip
+import zipfile
+
+# need to do some backflips to support Python 2 bz2 behavior
+# bz2 in Python 2 doesn't have an open function, and in Python 3
+# the BZ2File class only does binary mode
+try:
+    bz2.open
+except AttributeError:
+    bz2_open = bz2.BZ2File
+else:
+    def bz2_open(filename, mode):
+        mode += 't' if mode in ['r','w','a','x'] else ''
+        return bz2.open(filename, mode)
+
+# similar changes need to be made for gzip
+# gzip in Python 2 assumes text mode when 'r' is
+# specified and in Python 3 gzip assumes binary mode when
+# 'r' is specified
+try:
+    gzip.compress
+except AttributeError:
+    gzip_open = gzip.open
+else:
+    def gzip_open(filename, mode):
+        mode += 't' if mode in ['r','w','a','x'] else ''
+        return gzip.open(filename, mode)
+
+
+def anyopen(filename, mode='r'):
+    """Return a file stream for filename, even if compressed.
+
+    Supports files compressed with bzip2 (.bz2), gzip (.gz), and zip (.zip)
+    compression schemes. The appropriate extension must be present for
+    the function to properly handle the file.
+
+    Parameters
+    ----------
+    filename : str
+        Path to file to use.
+    mode : str
+        Mode for stream; usually 'r' or 'w'.
+
+    Returns
+    -------
+    stream : stream
+        Open stream for reading.
+
+    """
+    # opener for each type of file
+    extensions = {'.bz2': bz2_open,
+                  '.gz': gzip_open,
+                  '.zip': zipfile.ZipFile}
+
+    ext = os.path.splitext(filename)[1]
+
+    if ext in extensions:
+       opener= extensions[ext]
+
+    else:
+        opener = open
+
+    return opener(filename, mode)

--- a/qcsubmit/serializers.py
+++ b/qcsubmit/serializers.py
@@ -12,6 +12,7 @@ import yaml
 from pydantic import BaseModel
 
 from .exceptions import UnsupportedFiletypeError
+from .compression import anyopen
 
 __all__ = [
     "Serializer",
@@ -161,7 +162,7 @@ def get_format_name(file_name: str) -> str:
     Parameters:
         file_name: The name of the file from which we should work out the format.
     """
-    return file_name.split(".")[-1].lower()
+    return file_name.split(".")[1].lower()
 
 
 def serialize(serializable: Dict, file_name: str) -> None:
@@ -174,7 +175,7 @@ def serialize(serializable: Dict, file_name: str) -> None:
     """
     format_name = get_format_name(file_name)
     serializer = get_serializer(format_name)
-    with open(file_name, "w" + serializer.data_type.value) as output:
+    with anyopen(file_name, "w" + serializer.data_type.value) as output:
         output.write(serializer.serialize(serializable))
 
 
@@ -188,7 +189,7 @@ def deserialize(file_name: str) -> Dict:
     format_name = get_format_name(file_name)
     deserializer = get_deserializer(format_name)
     if os.path.exists(file_name):
-        with open(file_name, "r" + deserializer.data_type.value) as input_data:
+        with anyopen(file_name, "r" + deserializer.data_type.value) as input_data:
             return deserializer.deserialize(input_data)
     else:
         raise RuntimeError(f"The file {file_name} could not be found.")


### PR DESCRIPTION
## Description
This PR adds compression handling to serialization/deserialization. This supports the following compression schemes : extensions:
- `bzip2` : `bz2`
- `gzip` : `gz`
- `zip` : `zip`

Drawn directly from [alchemlyb](https://github.com/alchemistry/alchemlyb/blob/master/src/alchemlyb/parsing/util.py).

## Status
- [ ] Ready to go