### PR TITLE
Nonbonded Constraint Validation

### DIFF
--- a/qcsubmit/datasets.py
+++ b/qcsubmit/datasets.py
@@ -34,6 +34,7 @@ from .exceptions import (
 from .procedures import GeometricProcedure
 from .results import SingleResult
 from .validators import (
+    check_constraints,
     check_improper_connection,
     check_linear_torsions,
     check_torsion_connection,
@@ -303,6 +304,8 @@ class DatasetEntry(DatasetConfig):
             kwargs["initial_molecules"] = schema_mols
 
         super().__init__(**kwargs)
+        # validate any constraints being added
+        check_constraints(constraints=self.constraints, molecule=self.off_molecule)
         # now validate the torsions check proper first
         if self.dihedrals is not None:
             if off_molecule is None:
@@ -368,6 +371,8 @@ class DatasetEntry(DatasetConfig):
             raise ConstraintError(
                 f"The constraint {constraint} is not available please chose from freeze or set."
             )
+        # run the constraint check
+        check_constraints(constraints=self.constraints, molecule=self.off_molecule)
 
     @property
     def formatted_keywords(self) -> Dict[str, Any]:

--- a/qcsubmit/exceptions.py
+++ b/qcsubmit/exceptions.py
@@ -131,7 +131,7 @@ class DatasetCombinationError(QCSubmitException):
     The types of dataset are not the same and can not be combined.
     """
 
-    error_type = "dataset combination error"
+    error_type = "dataset_combination_error"
     header = "Dataset Combination Error"
 
 
@@ -140,5 +140,36 @@ class QCSpecificationError(QCSubmitException):
     The QCSpecification combination of method basis and program is not valid.
     """
 
-    error_type = "qcspecification error"
+    error_type = "qcspecification_error"
     header = "QCSpecification Error"
+
+
+class AngleConnectionError(QCSubmitException):
+    """
+    The tagged angle is not connected in this molecule and the constraint or grid opt could be incorrect.
+    """
+
+    error_type = "angle_connection_error"
+    header = "Angle Connection Error"
+
+
+class BondConnectionError(QCSubmitException):
+    """
+    The tagged bond is not connected in this molecule and the constraint or grid opt could be incorrect.
+    """
+
+    error_type = "bond_connection_error"
+    header = "Bond Connection Error"
+
+
+class AtomConnectionError(QCSubmitException):
+    """
+    A general connection error raised when a general connection check fails.
+    """
+
+    error_type = "atom_connection_error"
+    header = "Atom Connection Error"
+
+    def __init__(self, message: str, atoms):
+        super(AtomConnectionError, self).__init__(message=message)
+        self.atoms = atoms

--- a/qcsubmit/validators.py
+++ b/qcsubmit/validators.py
@@ -2,12 +2,16 @@
 Centralise the validators for easy reuse between factories and datasets.
 """
 
-from typing import Dict, Tuple
+from typing import Dict, List, Tuple
 
 import qcelemental as qcel
 from openforcefield import topology as off
 
+from .constraints import Constraints
 from .exceptions import (
+    AngleConnectionError,
+    AtomConnectionError,
+    BondConnectionError,
     DatasetInputError,
     DihedralConnectionError,
     LinearTorsionError,
@@ -125,19 +129,131 @@ def check_torsion_connection(
     Raises:
         DihedralConnectionError: If the proper dihedral is not valid for this molecule.
     """
+    try:
+        _ = check_general_connection(connected_atoms=torsion, molecule=molecule)
+    except AtomConnectionError as e:
+        raise DihedralConnectionError(
+            f"The dihedral {torsion} was not valid for the molecule {molecule}, as there is no bond between atoms {e.atoms}."
+        )
 
-    for i in range(3):
+    return torsion
+
+
+def check_bond_connection(
+    bond: Tuple[int, int], molecule: off.Molecule
+) -> Tuple[int, int]:
+    """
+    Check that the given bond indices create a connected bond in the molecule.
+
+    Parameters:
+        bond: The bond indices that should be checked.
+        molecule: The molecule which we want to check the bond in.
+
+    Returns:
+        The validated bond tuple
+
+    Raises:
+        BondConnectionError: If the given tuple is not connected in the molecule.
+    """
+    try:
+        _ = check_general_connection(connected_atoms=bond, molecule=molecule)
+    except AtomConnectionError:
+        raise BondConnectionError(
+            f"The bond {bond} was not valid for the molecule {molecule}, as there is no bond between these atoms."
+        )
+
+    return bond
+
+
+def check_angle_connection(
+    angle: Tuple[int, int, int], molecule: off.Molecule
+) -> Tuple[int, int, int]:
+    """
+    Check that the given angle indices create a connected angle in the molecule.
+
+    Parameters:
+        angle: The angle indices that should be checked.
+        molecule: The molecule which we want to check the angle in.
+
+    Returns:
+        The validated angle tuple.
+
+    Raises:
+        AngleConnectionError: If the given angle is not connected in the molecule.
+    """
+    try:
+        _ = check_general_connection(connected_atoms=angle, molecule=molecule)
+    except AtomConnectionError as e:
+        raise AngleConnectionError(
+            f"The angle {angle} was not valid for the molecule {molecule}, as there is no bond between atoms {e.atoms}"
+        )
+    return angle
+
+
+def check_general_connection(
+    connected_atoms: List[int], molecule: off.Molecule
+) -> List[int]:
+    """
+    Check that the list of atoms are all connected in order by explicit bonds in the given molecule.
+
+    Parameters:
+        connected_atoms: A list of the atom indices that should be connected in order.
+        molecule: The molecule that should be checked for connected atoms.
+
+    Raises:
+        AtomConnectionError: If any two of the given list of atoms are not connected.
+
+    Returns:
+        The list of validated connected atom indices.
+    """
+    for i in range(len(connected_atoms) - 1):
         # get the atoms to be checked
-        atoms = [torsion[i], torsion[i + 1]]
+        atoms = [connected_atoms[i], connected_atoms[i + 1]]
         try:
             _ = molecule.get_bond_between(*atoms)
         except (off.topology.NotBondedError, IndexError):
             # catch both notbonded errors and tags on atoms not in the molecule
-            raise DihedralConnectionError(
-                f"The dihedral {torsion} was not valid for the molecule {molecule}, as there is no bond between atoms {atoms}."
+            raise AtomConnectionError(
+                f"The set of atoms {connected_atoms} was not valid for the molecule {molecule}, as there is no bond between atoms {atoms}.",
+                atoms=atoms,
             )
 
-    return torsion
+    return connected_atoms
+
+
+def check_constraints(constraints: Constraints, molecule: off.Molecule) -> Constraints:
+    """
+    Warn the user if any of the constraints are between atoms which are not bonded.
+    """
+    import warnings
+
+    _constraint_to_check = {
+        "distance": check_bond_connection,
+        "angle": check_angle_connection,
+        "dihedral": check_torsion_connection,
+    }
+
+    if constraints.has_constraints:
+        # check each constraint and warn if it is incorrect
+        all_constraints = [
+            constraint
+            for constraint_set in [constraints.freeze, constraints.set]
+            for constraint in constraint_set
+        ]
+        for constraint in all_constraints:
+            if constraint.type != "xyz":
+                try:
+                    _constraint_to_check[constraint.type](constraint.indices, molecule)
+                except (
+                    BondConnectionError,
+                    AngleConnectionError,
+                    DihedralConnectionError,
+                ) as e:
+                    warnings.warn(
+                        f"The molecule {molecule} has non bonded constraints is this intentional see error for more information; {e.error_message}"
+                    )
+
+    return constraints
 
 
 def check_linear_torsions(
@@ -170,7 +286,7 @@ def check_linear_torsions(
 
 def check_valence_connectivity(molecule: qcel.models.Molecule) -> qcel.models.Molecule:
     """
-    Check if the given molecule is one single molecule, also warn about imcomplete valence.
+    Check if the given molecule is one single molecule, also warn about incomplete valence.
     """
 
     import warnings


### PR DESCRIPTION
## Description
This PR will address #45 and adds warnings to constraints (both freeze and set) that are added between atoms that are not bonded.
Adds a `check_constraints` validator.
This will need to be worked into the validation reports in the QCA submissions repo as well.


## Status
- [X] Ready to go