### PR TITLE
Improve large dataset performance

### DIFF
--- a/qcsubmit/datasets.py
+++ b/qcsubmit/datasets.py
@@ -1,6 +1,6 @@
 import json
 import os
-from typing import Any, Dict, List, Optional, Set, Tuple, Union
+from typing import Any, Dict, Generator, List, Optional, Set, Tuple, Union
 
 import numpy as np
 import qcelemental as qcel
@@ -305,11 +305,14 @@ class DatasetEntry(DatasetConfig):
 
         super().__init__(**kwargs)
         # validate any constraints being added
-        check_constraints(constraints=self.constraints, molecule=self.off_molecule)
+        check_constraints(
+            constraints=self.constraints,
+            molecule=self.get_off_molecule(include_conformers=False),
+        )
         # now validate the torsions check proper first
         if self.dihedrals is not None:
             if off_molecule is None:
-                off_molecule = self.off_molecule
+                off_molecule = self.get_off_molecule(include_conformers=False)
 
             # now validate the dihedrals
             for torsion in self.dihedrals:
@@ -341,9 +344,12 @@ class DatasetEntry(DatasetConfig):
         # now assign the new molecules
         self.initial_molecules = initial_molecules
 
-    @property
-    def off_molecule(self) -> off.Molecule:
-        """Build and openforcefield.topology.Molecule representation of the input molecule."""
+    def get_off_molecule(self, include_conformers: bool = True) -> off.Molecule:
+        """Build and openforcefield.topology.Molecule representation of the input molecule.
+
+        Parameters:
+            include_conformers: If `True` all of the input conformers are included else they are dropped.
+        """
 
         molecule = off.Molecule.from_mapped_smiles(
             mapped_smiles=self.attributes[
@@ -352,9 +358,10 @@ class DatasetEntry(DatasetConfig):
             allow_undefined_stereo=True,
         )
         molecule.name = self.index
-        for conformer in self.initial_molecules:
-            geometry = unit.Quantity(np.array(conformer.geometry), unit=unit.bohr)
-            molecule.add_conformer(geometry.in_units_of(unit.angstrom))
+        if include_conformers:
+            for conformer in self.initial_molecules:
+                geometry = unit.Quantity(np.array(conformer.geometry), unit=unit.bohr)
+                molecule.add_conformer(geometry.in_units_of(unit.angstrom))
         return molecule
 
     def add_constraint(
@@ -391,7 +398,10 @@ class DatasetEntry(DatasetConfig):
                 f"The constraint {constraint} is not available please chose from freeze or set."
             )
         # run the constraint check
-        check_constraints(constraints=self.constraints, molecule=self.off_molecule)
+        check_constraints(
+            constraints=self.constraints,
+            molecule=self.get_off_molecule(include_conformers=False),
+        )
 
     @property
     def formatted_keywords(self) -> Dict[str, Any]:
@@ -511,17 +521,21 @@ class BasicDataset(IndexCleaner, ClientHandler, QCSpecificationHandler, DatasetC
         new_dataset.metadata.elements.update(other.metadata.elements)
         for index, entry in other.dataset.items():
             # search for the molecule
-            entry_ids = new_dataset.get_molecule_entry(entry.off_molecule)
+            entry_ids = new_dataset.get_molecule_entry(
+                entry.get_off_molecule(include_conformers=False)
+            )
             if not entry_ids:
                 new_dataset.dataset[index] = entry
             else:
                 mol_id = entry_ids[0]
                 current_entry = new_dataset.dataset[mol_id]
                 _, atom_map = off.Molecule.are_isomorphic(
-                    entry.off_molecule, current_entry.off_molecule, return_atom_map=True
+                    entry.get_off_molecule(include_conformers=False),
+                    current_entry.get_off_molecule(include_conformers=False),
+                    return_atom_map=True,
                 )
                 # remap the molecule and all conformers
-                entry_mol = entry.off_molecule
+                entry_mol = entry.get_off_molecule(include_conformers=True)
                 mapped_mol = entry_mol.remap(mapping_dict=atom_map, current_to_new=True)
                 for i in range(mapped_mol.n_conformers):
                     mapped_schema = mapped_mol.to_qcschema(
@@ -546,11 +560,14 @@ class BasicDataset(IndexCleaner, ClientHandler, QCSpecificationHandler, DatasetC
         if isinstance(molecule, str):
             molecule = off.Molecule.from_smiles(molecule, allow_undefined_stereo=True)
 
-        hits = [
-            entry.index
-            for entry in self.dataset.values()
-            if molecule == entry.off_molecule
-        ]
+        # make a unique inchi key
+        inchi_key = molecule.to_inchikey(fixed_hydrogens=False)
+        hits = []
+        for entry in self.dataset.values():
+            if inchi_key == entry.attributes["inchi_key"]:
+                # they have same basic inchi now match the molecule
+                if molecule == entry.get_off_molecule(include_conformers=False):
+                    hits.append(entry.index)
 
         return hits
 
@@ -604,22 +621,38 @@ class BasicDataset(IndexCleaner, ClientHandler, QCSpecificationHandler, DatasetC
     @property
     def n_molecules(self) -> int:
         """
-        Calculate the total number of unique molecules which will be submitted as part of this dataset.
+        Calculate the number of unique molecules to be submitted.
 
         Returns:
-            The number of molecules in the dataset.
+            The number of unique molecules in dataset
 
-        Note:
-            The number of molecule records submitted is not always the same as the amount of records created, this can
-            also be checked using `n_records`. Here we give the number of unique molecules not excluding conformers.
-            * see also [n_conformers][qcsubmit.datasets.BasicDataset.n_conformers]
+        Notes:
+            * This method has been improved for better performance on large datasets and has been tested on an optimization dataset of over 10500 molecules.
+            * This function does not calculate the total number of entries of the dataset see `n_records`
         """
-
-        n_molecules = len(self.dataset)
-        return n_molecules
+        molecules = {}
+        for entry in self.dataset.values():
+            inchikey = entry.attributes["inchi_key"]
+            try:
+                like_mols = molecules[inchikey]
+                mol_to_add = entry.get_off_molecule(False).to_inchikey(
+                    fixed_hydrogens=True
+                )
+                for index in like_mols:
+                    if mol_to_add == self.dataset[index].get_off_molecule(
+                        False
+                    ).to_inchikey(fixed_hydrogens=True):
+                        break
+                else:
+                    molecules[inchikey].append(entry.index)
+            except KeyError:
+                molecules[inchikey] = [
+                    entry.index,
+                ]
+        return sum([len(value) for value in molecules.values()])
 
     @property
-    def molecules(self) -> off.Molecule:
+    def molecules(self) -> Generator[off.Molecule, None, None]:
         """
         A generator that creates an openforcefield.topology.Molecule one by one from the dataset.
 
@@ -632,7 +665,7 @@ class BasicDataset(IndexCleaner, ClientHandler, QCSpecificationHandler, DatasetC
 
         for molecule_data in self.dataset.values():
             # create the molecule from the cmiles data
-            yield molecule_data.off_molecule
+            yield molecule_data.get_off_molecule(include_conformers=True)
 
     @property
     def n_components(self) -> int:
@@ -1154,7 +1187,7 @@ class BasicDataset(IndexCleaner, ClientHandler, QCSpecificationHandler, DatasetC
 
         # now we load the molecules
         for data in self.dataset.values():
-            off_mol = data.off_molecule
+            off_mol = data.get_off_molecule(include_conformers=False)
             off_mol.name = None
             cell = report.NewCell()
             mol = off_mol.to_openeye()
@@ -1223,7 +1256,7 @@ class BasicDataset(IndexCleaner, ClientHandler, QCSpecificationHandler, DatasetC
         molecules = []
         tagged_atoms = []
         for data in self.dataset.values():
-            rdkit_mol = data.off_molecule.to_rdkit()
+            rdkit_mol = data.get_off_molecule(include_conformers=False).to_rdkit()
             AllChem.Compute2DCoords(rdkit_mol)
             molecules.append(rdkit_mol)
             if data.dihedrals is not None:
@@ -1345,7 +1378,9 @@ class OptimizationDataset(BasicDataset):
         new_dataset.metadata.elements.update(other.metadata.elements)
         for entry in other.dataset.values():
             # search for the molecule
-            entry_ids = new_dataset.get_molecule_entry(entry.off_molecule)
+            entry_ids = new_dataset.get_molecule_entry(
+                entry.get_off_molecule(include_conformers=False)
+            )
             if entry_ids:
                 records = 0
                 for mol_id in entry_ids:
@@ -1353,8 +1388,8 @@ class OptimizationDataset(BasicDataset):
                     # for each entry count the number of inputs incase we need a new entry
                     records += len(current_entry.initial_molecules)
                     _, atom_map = off.Molecule.are_isomorphic(
-                        entry.off_molecule,
-                        current_entry.off_molecule,
+                        entry.get_off_molecule(include_conformers=False),
+                        current_entry.get_off_molecule(include_conformers=False),
                         return_atom_map=True,
                     )
 
@@ -1376,7 +1411,7 @@ class OptimizationDataset(BasicDataset):
                     if current_constraints == entry_constraints:
                         # transfer the entries
                         # remap and transfer
-                        off_mol = entry.off_molecule
+                        off_mol = entry.get_off_molecule(include_conformers=True)
                         mapped_mol = off_mol.remap(
                             mapping_dict=atom_map, current_to_new=True
                         )
@@ -1401,17 +1436,6 @@ class OptimizationDataset(BasicDataset):
                 new_dataset.dataset[entry.index] = entry
 
         return new_dataset
-
-    @property
-    def n_molecules(self) -> int:
-        """
-        Calculate the number of unique molecules to be submitted.
-        """
-
-        molecules = set()
-        for molecule in self.molecules:
-            molecules.add(molecule)
-        return len(molecules)
 
     def _add_keywords(self, client: ptl.FractalClient) -> str:
         """
@@ -1608,11 +1632,15 @@ class TorsiondriveDataset(OptimizationDataset):
         new_dataset.metadata.elements.update(other.metadata.elements)
         for index, entry in other.dataset.items():
             # search for the molecule
-            entry_ids = new_dataset.get_molecule_entry(entry.off_molecule)
+            entry_ids = new_dataset.get_molecule_entry(
+                entry.get_off_molecule(include_conformers=False)
+            )
             for mol_id in entry_ids:
                 current_entry = new_dataset.dataset[mol_id]
                 _, atom_map = off.Molecule.are_isomorphic(
-                    entry.off_molecule, current_entry.off_molecule, return_atom_map=True
+                    entry.get_off_molecule(include_conformers=False),
+                    current_entry.get_off_molecule(include_conformers=False),
+                    return_atom_map=True,
                 )
 
                 # gather the current dihedrals forward and backwards
@@ -1632,7 +1660,7 @@ class TorsiondriveDataset(OptimizationDataset):
                 difference = current_dihedrals - other_dihedrals
                 if not difference:
                     # the entry is already there so add new conformers and skip
-                    off_mol = entry.off_molecule
+                    off_mol = entry.get_off_molecule(include_conformers=True)
                     mapped_mol = off_mol.remap(
                         mapping_dict=atom_map, current_to_new=True
                     )

--- a/qcsubmit/tests/test_datasets.py
+++ b/qcsubmit/tests/test_datasets.py
@@ -1134,7 +1134,7 @@ def test_wrong_metadata_collection_type(dataset_type):
     pytest.param(OptimizationDataset, id="OptimizationDataset"),
     pytest.param(TorsiondriveDataset, id="TorsiondriveDataset")
 ])
-def test_Dataset_exporting_same_type(dataset_type):
+def test_dataset_exporting_same_type(dataset_type):
     """
     Test making the given dataset from the json of another instance of the same dataset type.
     """
@@ -1180,7 +1180,27 @@ def test_get_molecule_entry(molecule_data):
     assert len(entries) == entries_no
 
 
-def test_BasicDataset_add_molecules_single_conformer():
+def test_get_entry_molecule():
+    """
+    Test getting a molecule with and without conformers from a dataset.
+    """
+    dataset = BasicDataset()
+    molecules = duplicated_molecules(include_conformers=True, duplicates=1)
+    for molecule in molecules:
+        index =molecule.to_smiles()
+        attributes = get_cmiles(molecule)
+        dataset.add_molecule(index=index, attributes=attributes, molecule=molecule)
+
+    # check the conformers are attached when requested
+    for entry in dataset.dataset.values():
+        mol_no_con = entry.get_off_molecule(include_conformers=False)
+        mol_con = entry.get_off_molecule(include_conformers=True)
+        assert mol_no_con.n_conformers == 0
+        assert mol_con.n_conformers == 1
+        assert mol_no_con == mol_con
+
+
+def test_basicdataset_add_molecules_single_conformer():
     """
     Test creating a basic dataset.
     """
@@ -1203,7 +1223,7 @@ def test_BasicDataset_add_molecules_single_conformer():
         assert mols[0].is_isomorphic_with(mols[1])
 
 
-def test_BasicDataset_add_molecules_conformers():
+def test_basicdataset_add_molecules_conformers():
     """
     Test adding a molecule with conformers which should each be expanded into their own qcportal.models.Molecule.
     """
@@ -1231,7 +1251,7 @@ def test_BasicDataset_add_molecules_conformers():
             assert mol.conformers[i].flatten().tolist() == pytest.approx(butane.conformers[i].flatten().tolist())
 
 
-def test_BasicDataset_coverage_reporter():
+def test_basicdataset_coverage_reporter():
     """
     Test generating coverage reports for openforcefield force fields.
     """
@@ -1255,7 +1275,7 @@ def test_BasicDataset_coverage_reporter():
         assert tag in coverage[ff]
 
 
-def test_Basicdataset_add_molecule_no_conformer():
+def test_basicdataset_add_molecule_no_conformer():
     """
     Test adding molecules with no conformers which should cause the validtor to generate one.
     """
@@ -1272,7 +1292,7 @@ def test_Basicdataset_add_molecule_no_conformer():
         assert molecule.n_conformers != 0
 
 
-def test_Basicdataset_add_molecule_missing_attributes():
+def test_basicdataset_add_molecule_missing_attributes():
     """
     Test adding a molecule to the dataset with a missing cmiles attribute this should raise an error.
     """
@@ -1294,7 +1314,7 @@ def test_Basicdataset_add_molecule_missing_attributes():
     pytest.param(("molecules.inchikey", "inchikey", "to_inchikey", {}, False), id="inchikey"),
     pytest.param(("molecules.hash", "hash", "to_hash", {}, True), id="hash error")
 ])
-def test_Basicdataset_molecules_to_file(file_data):
+def test_basicdataset_molecules_to_file(file_data):
     """
     Test exporting only the molecules in a dataset to file for each of the supported types.
     """
@@ -1365,7 +1385,7 @@ def test_dataset_to_pdf_no_torsions(toolkit_data):
     pytest.param(BasicDataset, id="BasicDataset"), pytest.param(OptimizationDataset, id="OptimizationDataset"),
     pytest.param(TorsiondriveDataset, id="TorsiondriveDataset")
 ])
-def test_Dataset_export_full_dataset_json(dataset_type):
+def test_dataset_export_full_dataset_json(dataset_type):
     """
     Test round tripping a full dataset via json.
     """
@@ -1398,7 +1418,7 @@ def test_Dataset_export_full_dataset_json(dataset_type):
     pytest.param((BasicDataset, TorsiondriveDataset), id="BasicDataSet to TorsiondriveDataset"),
     pytest.param((OptimizationDataset, TorsiondriveDataset), id="OptimizationDataset to TorsiondriveDataset"),
 ])
-def test_Dataset_export_full_dataset_json_mixing(dataset_type):
+def test_dataset_export_full_dataset_json_mixing(dataset_type):
     """
     Test round tripping a full dataset via json from one type to another this should fail as the dataset_types do not
     match.
@@ -1423,7 +1443,7 @@ def test_Dataset_export_full_dataset_json_mixing(dataset_type):
     pytest.param(BasicDataset, id="BasicDataset"), pytest.param(OptimizationDataset, id="OptimizationDataset"),
     pytest.param(TorsiondriveDataset, id="TorsiondriveDataset")
 ])
-def test_Dataset_export_dict(dataset_type):
+def test_dataset_export_dict(dataset_type):
     """
     Test making a new dataset from the dict of another of the same type.
     """
@@ -1458,7 +1478,7 @@ def test_Dataset_export_dict(dataset_type):
     pytest.param(OptimizationDataset, id="OptimizationDataset"),
     pytest.param(TorsiondriveDataset, id="TorsiondriveDataset")
 ])
-def test_Basicdataset_export_json(dataset_type):
+def test_basicdataset_export_json(dataset_type):
     """
     Test that the json serialisation works.
     """
@@ -1632,7 +1652,7 @@ def test_qc_spec_overwrite():
     assert spec.program == "torchani"
 
 
-def test_Basicdataset_schema():
+def test_basicdataset_schema():
     """
     Test that producing the schema still works.
     """
@@ -1647,7 +1667,7 @@ def test_Basicdataset_schema():
 @pytest.mark.parametrize("input_data", [
     pytest.param(("CCC", 0), id="basic core and tag=0"), pytest.param(("CC@@/_-1CC", 10), id="complex core and tag=10")
 ])
-def test_Basicdataset_clean_index(input_data):
+def test_basicdataset_clean_index(input_data):
     """
     Test that index cleaning is working, this checks if an index already has a numeric counter and strips it, this
     allows us to submit molecule indexs that start from a counter other than 0.
@@ -1663,7 +1683,7 @@ def test_Basicdataset_clean_index(input_data):
     assert counter == input_data[1]
 
 
-def test_Basicdataset_clean_index_normal():
+def test_basicdataset_clean_index_normal():
     """
     Test that index cleaning works when no numeric counter is on the index this should give back the core and 0 as the
     tag.
@@ -1675,7 +1695,7 @@ def test_Basicdataset_clean_index_normal():
     assert counter == 0
 
 
-def test_Basicdataset_filtering():
+def test_basicdataset_filtering():
     """
     Test adding filtered molecules to the dataset.
     """
@@ -1705,7 +1725,7 @@ def test_Basicdataset_filtering():
         assert mols[0].is_isomorphic_with(mols[1]) is True
 
 
-def test_Optimizationdataset_qc_spec():
+def test_optimizationdataset_qc_spec():
     """
     Test generating the qc spec for optimization datasets.
     """
@@ -1720,7 +1740,7 @@ def test_Optimizationdataset_qc_spec():
     assert qc_spec.driver == "gradient"
 
 
-def test_TorsionDriveDataset_torsion_indices():
+def test_torsiondrivedataset_torsion_indices():
     """
     Test adding molecules to a torsiondrive dataset with incorrect torsion indices.
     """

--- a/qcsubmit/tests/test_datasets.py
+++ b/qcsubmit/tests/test_datasets.py
@@ -1200,6 +1200,23 @@ def test_get_entry_molecule():
         assert mol_no_con == mol_con
 
 
+def test_dataset_nmolecules_tautomers():
+    """
+    We use inchikey to find the unique molecules however some tautomers can have the same inchikey so make sure we can still find the unique molecules by forceing the inchi_key to be the same.
+    """
+
+    dataset = BasicDataset()
+    molecules = duplicated_molecules(include_conformers=True, duplicates=1)
+    same_inchi  = molecules[0].to_inchikey(fixed_hydrogens=False)
+    for molecule in molecules:
+        index = molecule.to_smiles()
+        attributes = get_cmiles(molecule)
+        attributes["inchi_key"] = same_inchi
+        dataset.add_molecule(index=index, attributes=attributes, molecule=molecule)
+
+    assert dataset.n_molecules == len(molecules)
+
+
 def test_basicdataset_add_molecules_single_conformer():
     """
     Test creating a basic dataset.


### PR DESCRIPTION
## Description
This PR improves performance when dealing with datasets that contain a large number of molecules and/or conformers. Operations which include counting unique molecules or dataset searching lazy load TK molecules where possible and avoid building conformations always. 

This changes the API of the entry for building molecules from a property to a function `off_molecule` -> `get_off_molecule(include_conformers :bool)`. Conformers are still loaded when using the `dataset.molecules` generator.

## Status
- [X] Ready to go