### PR TITLE
Improve missing package error messages.

### DIFF
--- a/qcsubmit/factories.py
+++ b/qcsubmit/factories.py
@@ -184,11 +184,13 @@ class BasicDatasetFactory(ClientHandler, QCSpecificationHandler, BaseModel):
 
         for component in components:
             if issubclass(type(component), workflow_components.CustomWorkflowComponent):
-                if not component.is_available():
+                try:
+                    component.is_available()
+                except ModuleNotFoundError as e:
                     raise CompoenentRequirementError(
                         f"The component {component.component_name} could not be added to "
                         f"the workflow due to missing requirements"
-                    )
+                    ) from e
                 if component.component_name not in self.workflow.keys():
                     self.workflow[component.component_name] = component
                 else:

--- a/qcsubmit/tests/test_workflow_components.py
+++ b/qcsubmit/tests/test_workflow_components.py
@@ -510,7 +510,8 @@ def test_enumerating_protomers_apply():
     Test enumerating protomers which is only availabe in openeye.
     """
 
-    enumerate_protomers = workflow_components.EnumerateProtomers(max_states=2,)
+    enumerate_protomers = workflow_components.EnumerateProtomers(max_states=2)
+    assert enumerate_protomers.is_available()
 
     with pytest.raises(ValueError):
         # make sure rdkit is not allowed here
@@ -607,9 +608,8 @@ def test_fragmentation_apply():
     """
     Make sure that fragmentation is working.
     """
-
     fragmenter = workflow_components.WBOFragmenter()
-
+    assert fragmenter.is_available()
     # check that a molecule with no rotatable bonds fails if we dont want the parent back
     benzene = Molecule.from_file(get_data("benzene.sdf"), "sdf")
     result = fragmenter.apply([benzene, ], processors=1)
@@ -761,7 +761,7 @@ def test_smarts_filter_apply_tag_torsions(tag_dihedrals):
 
     molecules = get_tautomers()
     # this should filter and tag the dihedrals
-    result = filter.apply(molecules)
+    result = filter.apply(molecules, processors=1)
     for molecule in result.molecules:
         if tag_dihedrals:
             assert "dihedrals" in molecule.properties

--- a/qcsubmit/workflow_components/fragmentation.py
+++ b/qcsubmit/workflow_components/fragmentation.py
@@ -5,6 +5,7 @@ from typing import Dict, List, Optional, Union
 
 from openforcefield.topology import Molecule
 from pydantic import validator
+from qcelemental.util import which_import
 
 from ..common_structures import ComponentProperties, TorsionIndexer
 from ..datasets import ComponentResult
@@ -75,15 +76,21 @@ class WBOFragmenter(ToolkitValidator, CustomWorkflowComponent):
         """
         Check if fragmenter can be imported.
         """
+        openeye = which_import(
+            ".oechem",
+            raise_error=True,
+            return_bool=True,
+            package="openeye",
+            raise_msg="Please install via `conda install openeye-toolkits -c openeye`.",
+        )
+        fragmenter = which_import(
+            "fragmenter",
+            raise_error=True,
+            return_bool=True,
+            raise_msg="Please install via `conda install fragmenter -c omnia`.",
+        )
 
-        try:
-            import fragmenter
-            import openeye
-
-            return True
-
-        except ImportError:
-            return False
+        return openeye and fragmenter
 
     def _apply(self, molecules: List[Molecule]) -> ComponentResult:
         """


### PR DESCRIPTION
## Description
This PR makes use of QCElementals `which_import` function which allows us to raise detailed error messages with instructions on how to install missing packages for components.

New components which depend on a specific backend toolkit like openeye such as the protomer enumeration component can have import errors raised automatically by only setting openeye in the available toolkits dict and inheriting from the `ToolkitValidator` class

```python
class EnumerateProtomers(ToolkitValidator, CustomWorkflowComponent):
    """
    Enumerate the formal charges of the input molecule using the backend toolkits through the OFFTK.

    Note:
        Only Openeye is supported so far.
    """

    component_name = "EnumerateProtomers"
    component_description = "Enumerate the protomers of the molecule if possible."
    component_fail_message = "The molecules formal charges could not be enumerated possibly due to a missing toolkit."

    # restrict the allowed toolkits for this module
    toolkit = "openeye"
    _toolkits = {"openeye": OpenEyeToolkitWrapper}
```

## Status
- [X] Ready to go