### PR TITLE
Improve missing basis checks

### DIFF
--- a/qcsubmit/datasets.py
+++ b/qcsubmit/datasets.py
@@ -819,6 +819,7 @@ class BasicDataset(IndexCleaner, ClientHandler, QCSpecificationHandler, DatasetC
             raise_errors: bool, default=True
                 if True the function will raise an error for missing basis coverage, else we return the missing data and just print warnings.
         """
+        import re
         import warnings
 
         import basis_set_exchange as bse
@@ -839,9 +840,14 @@ class BasicDataset(IndexCleaner, ClientHandler, QCSpecificationHandler, DatasetC
 
             elif spec.program.lower() == "psi4":
                 # now check psi4
-                # TODO this list should be updated with more basis transfroms as we find them
+                # TODO this list should be updated with more basis transforms as we find them
                 psi4_converter = {"dzvp": "dgauss-dzvp"}
                 basis = psi4_converter.get(spec.basis.lower(), spec.basis.lower())
+                # here we need to apply conversions for special characters to match bse
+                # replace the *
+                basis = re.sub("\*", "_st_", basis)
+                # replace any /
+                basis = re.sub("/", "_sl_", basis)
                 basis_meta = bse.get_metadata()[basis]
                 elements = basis_meta["versions"][basis_meta["latest_version"]][
                     "elements"

--- a/qcsubmit/tests/test_datasets.py
+++ b/qcsubmit/tests/test_datasets.py
@@ -1567,7 +1567,9 @@ def test_dataset_roundtrip_compression(dataset_type, compression):
     pytest.param(({"method": "wb97x-d", "basis": "aug-cc-pV(5+d)Z", "program": "psi4"}, {"I", "C", "H"}, True), id="aug-cc-pV(5+d)Z Error"),
     pytest.param(({"method": "openff-1.0.0", "basis": "smirnoff", "program": "openmm"}, {"C", "H", "N"}, False), id="Smirnoff Pass"),
     pytest.param(({"method": "GFN2-xTB", "basis": None, "program": "xtb"}, {"C", "N", "Se"}, False), id="XTB Pass"),
-    pytest.param(({"method": "uff", "basis": None, "program": "rdkit"}, {"C", "N", "O"}, False), id="Rdkit UFF Pass")
+    pytest.param(({"method": "uff", "basis": None, "program": "rdkit"}, {"C", "N", "O"}, False), id="Rdkit UFF Pass"),
+    pytest.param(({"method": "hf", "basis": "6-311++G**", "program": "psi4"}, {"Br", "C", "O", "N"}, True), id="6-311++G** regex sub Error"),
+    pytest.param(({"method": "hf", "basis": "cc-pV5Z(fi/sf/fw)", "program": "psi4"}, {"Br", "C", "O", "N"}, False), id="cc-pV5Z(fi/sf/fw) regex Pass")
 ])
 def test_basis_coverage_single(basis_data):
     """
@@ -1608,7 +1610,7 @@ def test_basis_coverage_multiple():
     # get the coverage
     basis_coverage = dataset._get_missing_basis_coverage(raise_errors=False)
     # all should pass but ani
-    ani_report  = basis_coverage.pop("torchani")
+    ani_report = basis_coverage.pop("torchani")
     assert ani_report == {"I"}
     # make sure the rest are all empty
     for report in basis_coverage.values():


### PR DESCRIPTION
## Description
Missing basis coverage checks can often fail if the basis name can not be found in the basis set exchange package. Here we now convert basis with `*` or `/` in their name to the correct format allowing them to be validated correctly. 

`* -> _st_`
`/ -> _sl_`

## Status
- [X] Ready to go