### PR TITLE
Factory style workflow components

### DIFF
--- a/qcsubmit/exceptions.py
+++ b/qcsubmit/exceptions.py
@@ -48,9 +48,18 @@ class MissingWorkflowComponentError(QCSubmitException):
     header = "QCSubmit Missing Workflow Component Error"
 
 
-class CompoenentRequirementError(QCSubmitException):
+class ComponentRegisterError(QCSubmitException):
     """
-    The requested workflow componenet could not be added due to missing requirements.
+    A component with this name has already been registered with QCSubmit.
+    """
+
+    error_type = "component_registered_error"
+    header = "QCSubmit Component Registered Error"
+
+
+class ComponentRequirementError(QCSubmitException):
+    """
+    The requested workflow component could not be added due to missing requirements.
     """
 
     error_type = "missing_requirements_error"
@@ -63,7 +72,7 @@ class InvalidClientError(QCSubmitException):
     """
 
     error_type = "invalid_client_error"
-    header = "QCSumit Invalid Client Error"
+    header = "QCSubmit Invalid Client Error"
 
 
 class DriverError(QCSubmitException):

--- a/qcsubmit/workflow_components/__init__.py
+++ b/qcsubmit/workflow_components/__init__.py
@@ -1,3 +1,9 @@
+from .base import (
+    deregister_component,
+    get_component,
+    list_components,
+    register_component,
+)
 from .base_component import BasicSettings, CustomWorkflowComponent, ToolkitValidator
 from .conformer_generation import StandardConformerGenerator
 from .filters import (

--- a/qcsubmit/workflow_components/base.py
+++ b/qcsubmit/workflow_components/base.py
@@ -1,0 +1,142 @@
+"""
+The base file with functions to register and de register new workflow components.
+"""
+
+from typing import Dict, List, Union
+
+from ..exceptions import ComponentRegisterError, InvalidWorkflowComponentError
+from .base_component import CustomWorkflowComponent
+from .conformer_generation import StandardConformerGenerator
+from .filters import (
+    CoverageFilter,
+    ElementFilter,
+    MolecularWeightFilter,
+    RMSDCutoffConformerFilter,
+    RotorFilter,
+    SmartsFilter,
+)
+from .fragmentation import WBOFragmenter
+from .state_enumeration import (
+    EnumerateProtomers,
+    EnumerateStereoisomers,
+    EnumerateTautomers,
+)
+
+__all__ = [
+    "register_component",
+    "deregister_component",
+    "get_component",
+    "list_components",
+]
+
+workflow_components: Dict[str, CustomWorkflowComponent] = {}
+
+
+def register_component(
+    component: CustomWorkflowComponent, replace: bool = False
+) -> None:
+    """
+    Register a valid workflow component with qcsubmit.
+
+    Parameters:
+        component: The workflow component to be registered with QCSubmit.
+        replace: If the new component should replace any other component with the same name.
+
+    Raises:
+        ComponentRegisterError: If a component has already been registered under this name.
+        InvalidWorkflowComponentError: If the new component is not a sub class of the bass workflow component.
+    """
+
+    if issubclass(type(component), CustomWorkflowComponent):
+        component_name = component.component_name.lower()
+        if component_name not in workflow_components or (
+            component_name in workflow_components and replace
+        ):
+            workflow_components[component_name] = component
+        else:
+            raise ComponentRegisterError(
+                f"There is already a component registered with QCSubmit with the name {component.component_name}, to replace this use the `replace=True` flag."
+            )
+    else:
+        raise InvalidWorkflowComponentError(
+            f"Component {component} rejected as it is not a sub class of CustomWorkflowComponent"
+        )
+
+
+def get_component(component_name: str) -> CustomWorkflowComponent:
+    """
+    Get the registered workflow component by component name.
+
+    Parameters:
+        component_name: The name the component is registered as.
+
+    Returns:
+        The requested workflow component.
+
+    Raises:
+        ComponentRegisterError: If not component is registered under this name.
+    """
+
+    component = workflow_components.get(component_name.lower(), None)
+    if component is None:
+        raise ComponentRegisterError(
+            f"No component is registered with QCSubmit under the name {component_name}."
+        )
+
+    return component
+
+
+def deregister_component(component: Union[CustomWorkflowComponent, str]) -> None:
+    """
+    Deregister the workflow component from QCSubmit.
+
+    Parameters:
+        component: The name or instance of the component which should be removed.
+
+    Raises:
+        ComponentRegisterError: If the component to be removed was not registered.
+    """
+
+    if issubclass(type(component), CustomWorkflowComponent):
+        component_name = component.component_name.lower()
+
+    else:
+        component_name = component.lower()
+
+    wc = workflow_components.pop(component_name, None)
+    if wc is None:
+        raise ComponentRegisterError(
+            f"The component {component} could not be removed as it was not registered."
+        )
+
+
+def list_components() -> List[CustomWorkflowComponent]:
+    """
+    Get a list of all of the currently registered workflow components.
+
+    Returns:
+        A list of the workflow components which are currently registered.
+    """
+
+    return list(workflow_components.values())
+
+
+# register the current components
+# conformer generation
+register_component(StandardConformerGenerator())
+
+# fragmentation
+register_component(WBOFragmenter())
+
+# filters
+register_component(RotorFilter())
+register_component(RMSDCutoffConformerFilter())
+register_component(SmartsFilter())
+register_component(CoverageFilter())
+register_component(MolecularWeightFilter())
+register_component(ElementFilter())
+
+# state enumeration
+register_component(EnumerateTautomers())
+register_component(EnumerateStereoisomers())
+register_component(EnumerateProtomers())

--- a/qcsubmit/workflow_components/base_component.py
+++ b/qcsubmit/workflow_components/base_component.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Optional
 import tqdm
 from openforcefield.topology import Molecule
 from openforcefield.utils.toolkits import OpenEyeToolkitWrapper, RDKitToolkitWrapper
-from pydantic import BaseModel, validator
+from pydantic import BaseModel, Field, validator
 from pydantic.main import ModelMetaclass
 from qcelemental.util import which_import
 
@@ -38,10 +38,21 @@ class CustomWorkflowComponent(BaseModel, abc.ABC, metaclass=InheritSlots):
     factory code
     """
 
-    component_name: str
-    component_description: str
-    component_fail_message: str
-    _properties: ComponentProperties
+    component_name: str = Field(
+        ..., description="The name of the component which should match the class name."
+    )
+    component_description: str = Field(
+        ...,
+        description="A short description of what the component will do to the molecules.",
+    )
+    component_fail_message: str = Field(
+        ...,
+        description="A short description with hints on why the molecule may have caused an error in this workflow component.",
+    )
+    _properties: ComponentProperties = Field(
+        ...,
+        description="The internal runtime properties of the component which can not be changed, these indecate if the component can be ran in parallel and if it may produce duplicate molecules.",
+    )
     _cache: Dict
 
     class Config:
@@ -230,7 +241,10 @@ class ToolkitValidator(BaseModel):
         [ToolkitValidator][qcsubmit.workflow_components.base_component.ToolkitValidator] mixin.
     """
 
-    toolkit: str = "openeye"
+    toolkit: str = Field(
+        "openeye",
+        description="The name of the toolkit which should be used in this component.",
+    )
     _toolkits: Dict = {"rdkit": RDKitToolkitWrapper, "openeye": OpenEyeToolkitWrapper}
 
     @validator("toolkit")

--- a/qcsubmit/workflow_components/conformer_generation.py
+++ b/qcsubmit/workflow_components/conformer_generation.py
@@ -2,6 +2,7 @@ from typing import List, Optional
 
 import simtk.unit as unit
 from openforcefield.topology import Molecule
+from pydantic import Field
 
 from qcsubmit.datasets import ComponentResult
 
@@ -26,9 +27,16 @@ class StandardConformerGenerator(ToolkitValidator, CustomWorkflowComponent):
     # custom components for this class
     _properties = ComponentProperties(process_parallel=True, produces_duplicates=False)
 
-    rms_cutoff: Optional[float] = None
-    max_conformers: int = 10
-    clear_existing: bool = True
+    rms_cutoff: Optional[float] = Field(
+        None,
+        description="The rms cut off in angstroms to be used when generating the conformers. Passing None will use the default in toolkit of 1.",
+    )
+    max_conformers: int = Field(
+        10, description="The maximum number of conformers to be generated per molecule."
+    )
+    clear_existing: bool = Field(
+        True, description="If any pre-existing conformers should be kept."
+    )
 
     def _apply_init(self, result: ComponentResult) -> None:
         """

--- a/qcsubmit/workflow_components/state_enumeration.py
+++ b/qcsubmit/workflow_components/state_enumeration.py
@@ -5,6 +5,7 @@ from typing import List
 
 from openforcefield.topology import Molecule
 from openforcefield.utils.toolkits import OpenEyeToolkitWrapper
+from pydantic import Field
 
 from ..common_structures import ComponentProperties
 from ..datasets import ComponentResult
@@ -32,7 +33,9 @@ class EnumerateTautomers(ToolkitValidator, CustomWorkflowComponent):
     component_fail_message = "The molecule tautomers could not be enumerated."
 
     # custom settings for the class
-    max_tautomers: int = 20
+    max_tautomers: int = Field(
+        20, description="The maximum number of tautomers that should be generated."
+    )
     _properties = ComponentProperties(process_parallel=True, produces_duplicates=True)
 
     def _apply_init(self, result: ComponentResult) -> None:
@@ -105,9 +108,17 @@ class EnumerateStereoisomers(ToolkitValidator, CustomWorkflowComponent):
         "The molecules stereo centers or bonds could not be enumerated"
     )
     _properties = ComponentProperties(process_parallel=True, produces_duplicates=True)
-    undefined_only: bool = False
-    max_isomers: int = 20
-    rationalise: bool = True
+    undefined_only: bool = Field(
+        False,
+        description="If we should only enumerate parts of the molecule with undefined stereochemistry or all stereochemistry.",
+    )
+    max_isomers: int = Field(
+        20, description="The maximum number of stereoisomers to be generated."
+    )
+    rationalise: bool = Field(
+        True,
+        description="If we should check that the resulting molecules are physically possible by attempting to generate conformers for them.",
+    )
 
     def _apply_init(self, result: ComponentResult) -> None:
 
@@ -174,7 +185,9 @@ class EnumerateProtomers(ToolkitValidator, CustomWorkflowComponent):
     _toolkits = {"openeye": OpenEyeToolkitWrapper}
     _properties = ComponentProperties(process_parallel=True, produces_duplicates=True)
 
-    max_states: int = 10
+    max_states: int = Field(
+        10, description="The maximum number of states that should be generated."
+    )
 
     def _apply_init(self, result: ComponentResult) -> None:
 


### PR DESCRIPTION
## Description
In order to make it easier for users to add new custom workflow components this switches to a factory design where they can registered. This allows qcsubmit to automatically load them from JSON/YAML if they have been registered first. We have also updated the pydantic models to use Fields to properly define the schema this will be expanded to factories and datasets latter.  

New components can now be registered using the new  function `register_component()`, they are then removed using `deregister_component()`. A list of all currently registered components can be generated using `list_components()` and finally an instance of a component can be made with its default settings using `get_component()`.

The fragmenter attribute `heuristic`  is removed to gain compatibility with fragmenter 0.0.7 as this is now hard coded to `path_length` which was the QCSubmit default.

## Status
- [X] Ready to go