### PR TITLE
MBIS options

### DIFF
--- a/qcsubmit/factories.py
+++ b/qcsubmit/factories.py
@@ -26,7 +26,7 @@ from .exceptions import (
 from .procedures import GeometricProcedure
 from .serializers import deserialize, serialize
 from .validators import scf_property_validator
-from .workflow_components import CustomWorkflowComponent, get_component, list_components
+from .workflow_components import CustomWorkflowComponent, get_component
 
 
 class BasicDatasetFactory(ClientHandler, QCSpecificationHandler, BaseModel):

--- a/qcsubmit/validators.py
+++ b/qcsubmit/validators.py
@@ -70,6 +70,7 @@ def scf_property_validator(scf_property: str) -> str:
         "lowdin_charges",
         "wiberg_lowdin_indices",
         "mayer_indices",
+        "mbis_charges",
     ]
 
     if scf_property.lower() not in allowed_properties:


### PR DESCRIPTION
## Description
Expand the SCF property validator to allow for the new [MBIS properties](http://www.psicode.org/psi4manual/master/oeprop.html), this can be requested by adding the `mbis_charges` keyword to the `scf_properties` factory and dataset attributes. 
Fixes #63 

Also, remove an unused import.

## Status
- [X] Ready to go