### PR TITLE
Dataset update

### DIFF
--- a/devtools/conda-envs/psi4_env.yaml
+++ b/devtools/conda-envs/psi4_env.yaml
@@ -23,6 +23,7 @@ dependencies:
   - qcportal >=0.13.0
   - qcengine >=0.15.0
   - psi4 >=1.3
+  - pcmsolver ==1.2.1
   - openeye-toolkits ==2019.10.2
   - qcfractal >=0.13.0
   - torsiondrive

--- a/devtools/conda-envs/psi4_env.yaml
+++ b/devtools/conda-envs/psi4_env.yaml
@@ -28,6 +28,7 @@ dependencies:
   - torsiondrive
   - fragmenter
   - basis_set_exchange
+  - typing-extensions
 
     # Pip-only installs
 #  - pip:

--- a/devtools/conda-envs/psi4_env.yaml
+++ b/devtools/conda-envs/psi4_env.yaml
@@ -22,7 +22,7 @@ dependencies:
   - codecov
   - qcportal >=0.13.0
   - qcengine >=0.15.0
-  - psi4 >=1.3
+  - psi4 ==1.4a3.dev1+8afefb7
   - pcmsolver ==1.2.1
   - openeye-toolkits ==2019.10.2
   - qcfractal >=0.13.0

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -26,6 +26,7 @@ dependencies:
   - torsiondrive
   - fragmenter
   - basis_set_exchange
+  - typing-extensions
 
     # Pip-only installs
 #  - pip:

--- a/qcsubmit/common_structures.py
+++ b/qcsubmit/common_structures.py
@@ -53,6 +53,32 @@ class ComponentProperties(BaseModel):
         extra: "forbid"
 
 
+class TDSettings(DatasetConfig):
+    """
+    A replacement of the TDKeywords class in the QCFractal which drops the dihedrals field as this is moved up the model.
+    The settings here overwrite the gloab dataset and allow the user to have control over the individual scans.
+    """
+
+    grid_spacing: Optional[List[int]] = Field(
+        None, description="List of grid spacings for the dihedral scan in degrees."
+    )
+    dihedral_ranges: Optional[List[Tuple[int, int]]] = Field(
+        None,
+        description="A list of the dihedral scan limits of the form (lower, upper)",
+    )
+    energy_decrease_thresh: Optional[float] = Field(
+        None,
+        description="The threshold of the smallest energy decrease amount to trigger activating optimizations from "
+        "grid point.",
+    )
+    energy_upper_limit: Optional[float] = Field(
+        None,
+        description="The threshold if the energy of a grid point that is higher than the current global minimum, to "
+        "start new optimizations, in unit of a.u. I.e. if energy_upper_limit = 0.05, current global "
+        "minimum energy is -9.9 , then a new task starting with energy -9.8 will be skipped.",
+    )
+
+
 class PCMSettings(ResultsConfig):
     """
     A class to handle PCM settings which can be used with PSi4.

--- a/qcsubmit/data/invalid_linear_dataset.json
+++ b/qcsubmit/data/invalid_linear_dataset.json
@@ -1,7 +1,7 @@
 {
-  "dataset_name": "BasicDataset",
+  "dataset_name": "TorsionDriveDataset",
   "dataset_tagline": "OpenForcefield single point evaluations.",
-  "dataset_type": "DataSet",
+  "dataset_type": "TorsionDriveDataset",
   "method": "B3LYP-D3BJ",
   "basis": "DZVP",
   "program": "psi4",

--- a/qcsubmit/datasets/__init__.py
+++ b/qcsubmit/datasets/__init__.py
@@ -1,0 +1,10 @@
+from .dataset_utils import list_datasets, load_dataset, register_dataset
+from .datasets import (
+    BasicDataset,
+    ComponentResult,
+    DatasetEntry,
+    OptimizationDataset,
+    OptimizationEntry,
+    TorsiondriveDataset,
+    TorsionDriveEntry,
+)

--- a/qcsubmit/datasets/dataset_utils.py
+++ b/qcsubmit/datasets/dataset_utils.py
@@ -1,0 +1,82 @@
+"""
+A set of utility functions to help with loading datasets.
+"""
+from typing import Any, Dict, List, Union
+
+from ..exceptions import DatasetRegisterError, InvalidDatasetError
+from ..serializers import deserialize
+from .datasets import BasicDataset, OptimizationDataset, TorsiondriveDataset
+
+registered_datasets: Dict[str, Any] = {}
+
+
+def load_dataset(data: Union[str, Dict]) -> "BasicDataset":
+    """
+    Create a new instance dataset from the file or dict of the dataset. This removes the need of knowing what the dataset type is.
+
+    Parameters:
+        data: The file path or dict of the dataset from which we should load the data.
+
+    Raises:
+        DatasetRegisterError: If no registered dataset can load the given dataset type.
+
+    Returns:
+        An instance of the correct dataset loaded with the data.
+    """
+    if isinstance(data, str):
+        # load the file
+        raw_data = deserialize(data)
+    else:
+        raw_data = data
+
+    dataset_type = registered_datasets.get(raw_data["dataset_type"].lower(), None)
+    if dataset_type is not None:
+        return dataset_type(**raw_data)
+    else:
+        raise DatasetRegisterError(
+            f"No registered dataset can load the type {dataset_type}."
+        )
+
+
+def register_dataset(dataset: Any, replace: bool = False) -> None:
+    """
+    Register a dataset with qcsubmit making it easy to auto load the model from file.
+
+    Parameters:
+        dataset: The dataset class that should be registered.
+        replace: If the new dataset should replace any other dataset of the same type
+
+    Raises:
+        InvalidDatasetError: If the dataset is not a valid sub class of the basic dataset model
+        DatasetRegisterError: If a dataset of this type has already been registered
+    """
+
+    if issubclass(dataset, BasicDataset):
+        dataset_type = dataset.__fields__["dataset_type"].default.lower()
+
+        if dataset_type not in registered_datasets or (
+            dataset_type in registered_datasets and replace
+        ):
+            registered_datasets[dataset_type] = dataset
+        else:
+            raise DatasetRegisterError(
+                f"A dataset was already registered with the type {dataset_type}, to replace this use the `replace=True` flag."
+            )
+
+    else:
+        raise InvalidDatasetError(
+            f"Dataset {dataset} rejected as it is not a valid sub class of the BasicDataset."
+        )
+
+
+def list_datasets() -> List[str]:
+    """
+    Returns:
+        A list of all of the currently registered dataset classes.
+    """
+    return list(registered_datasets.values())
+
+
+register_dataset(BasicDataset)
+register_dataset(OptimizationDataset)
+register_dataset(TorsiondriveDataset)

--- a/qcsubmit/datasets/entries.py
+++ b/qcsubmit/datasets/entries.py
@@ -184,7 +184,7 @@ class TorsionDriveEntry(DatasetEntry):
     A Torsiondrive dataset specific class which can check dihedral indices and store torsiondrive specific settings with built in validation.
     """
 
-    dihedrals: Optional[List[Tuple[int, int, int, int]]]
+    dihedrals: List[Tuple[int, int, int, int]]
     keywords: Optional[TDSettings] = TDSettings()
 
     def __init__(self, off_molecule: Optional[off.Molecule] = None, **kwargs):

--- a/qcsubmit/datasets/entries.py
+++ b/qcsubmit/datasets/entries.py
@@ -1,0 +1,235 @@
+"""
+All of the individual dataset entry types are defined here.
+"""
+
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+import openforcefield.topology as off
+import qcelemental as qcel
+from pydantic import validator
+from simtk import unit
+
+from ..common_structures import DatasetConfig, TDSettings
+from ..constraints import Constraints
+from ..exceptions import ConstraintError, DihedralConnectionError
+from ..validators import (
+    check_constraints,
+    check_improper_connection,
+    check_linear_torsions,
+    check_torsion_connection,
+    check_valence_connectivity,
+    cmiles_validator,
+)
+
+
+class DatasetEntry(DatasetConfig):
+    """
+    A basic data class to construct the datasets which holds any information about the molecule and options used in
+    the qcarchive calculation.
+
+    Note:
+        * ``extras`` are passed into the qcelemental.models.Molecule on creation.
+        * any extras that should passed to the calculation like extra constrains should be passed to ``keywords``.
+    """
+
+    index: str
+    initial_molecules: List[qcel.models.Molecule]
+    attributes: Dict[str, Any]
+    extras: Optional[Dict[str, Any]] = {}
+    keywords: Optional[Dict[str, Any]] = {}
+
+    _attribute_validator = validator("attributes", allow_reuse=True)(cmiles_validator)
+    _qcel_molecule_validator = validator(
+        "initial_molecules", allow_reuse=True, each_item=True
+    )(check_valence_connectivity)
+
+    def __init__(self, off_molecule: Optional[off.Molecule] = None, **kwargs):
+        """
+        Init the dataclass handling conversions of the molecule first.
+        This is needed to make sure the extras are passed into the qcschema molecule.
+        """
+
+        extras = kwargs["extras"]
+        # if we get an off_molecule we need to convert it
+        if off_molecule is not None:
+            if off_molecule.n_conformers == 0:
+                off_molecule.generate_conformers(n_conformers=1)
+            schema_mols = [
+                off_molecule.to_qcschema(conformer=conformer, extras=extras)
+                for conformer in range(off_molecule.n_conformers)
+            ]
+            kwargs["initial_molecules"] = schema_mols
+
+        super().__init__(**kwargs)
+
+        # now we need to process all of the initial molecules to make sure the cmiles is present
+        # and force c1 symmetry
+        initial_molecules = []
+        for mol in self.initial_molecules:
+            extras = mol.extras or {}
+            extras[
+                "canonical_isomeric_explicit_hydrogen_mapped_smiles"
+            ] = self.attributes["canonical_isomeric_explicit_hydrogen_mapped_smiles"]
+            mol_data = mol.dict()
+            mol_data["extras"] = extras
+            # put into strict c1 symmetry
+            mol_data["fix_symmetry"] = "c1"
+            initial_molecules.append(qcel.models.Molecule.parse_obj(mol_data))
+        # now assign the new molecules
+        self.initial_molecules = initial_molecules
+
+    def get_off_molecule(self, include_conformers: bool = True) -> off.Molecule:
+        """Build and openforcefield.topology.Molecule representation of the input molecule.
+
+        Parameters:
+            include_conformers: If `True` all of the input conformers are included else they are dropped.
+        """
+
+        molecule = off.Molecule.from_mapped_smiles(
+            mapped_smiles=self.attributes[
+                "canonical_isomeric_explicit_hydrogen_mapped_smiles"
+            ],
+            allow_undefined_stereo=True,
+        )
+        molecule.name = self.index
+        if include_conformers:
+            for conformer in self.initial_molecules:
+                geometry = unit.Quantity(np.array(conformer.geometry), unit=unit.bohr)
+                molecule.add_conformer(geometry.in_units_of(unit.angstrom))
+        return molecule
+
+
+class OptimizationEntry(DatasetEntry):
+    """
+    An optimization dataset specific entry class which can handle constraints.
+    """
+
+    constraints: Constraints = Constraints()
+
+    def __init__(self, off_molecule: Optional[off.Molecule] = None, **kwargs):
+        """
+        Here we handle the constraints before calling the super.
+        """
+        # if the constraints are in the keywords move them out for validation
+        if "constraints" in kwargs["keywords"]:
+            constraint_dict = kwargs["keywords"].pop("constraints")
+            constraints = Constraints(**constraint_dict)
+            kwargs["constraints"] = constraints
+
+        super().__init__(off_molecule, **kwargs)
+        # validate any constraints being added
+        check_constraints(
+            constraints=self.constraints,
+            molecule=self.get_off_molecule(include_conformers=False),
+        )
+
+    def add_constraint(
+        self,
+        constraint: str,
+        constraint_type: str,
+        indices: List[int],
+        bonded: bool = True,
+        **kwargs,
+    ) -> None:
+        """
+        Add new constraint of the given type.
+
+        Parameters:
+            constraint: The major type of constraint, freeze or set
+            constraint_type: the constraint sub type, angle, distance etc
+            indices: The atom indices the constraint should be placed on
+            bonded: If the constraint is intended to be put a bonded set of atoms
+            kwargs: Any extra information needed by the constraint, for the set class they need a value `value=float`
+        """
+        if constraint.lower() == "freeze":
+            self.constraints.add_freeze_constraint(
+                constraint_type=constraint_type, indices=indices, bonded=bonded
+            )
+        elif constraint.lower() == "set":
+            self.constraints.add_set_constraint(
+                constraint_type=constraint_type,
+                indices=indices,
+                bonded=bonded,
+                **kwargs,
+            )
+        else:
+            raise ConstraintError(
+                f"The constraint {constraint} is not available please chose from freeze or set."
+            )
+        # run the constraint check
+        check_constraints(
+            constraints=self.constraints,
+            molecule=self.get_off_molecule(include_conformers=False),
+        )
+
+    @property
+    def formatted_keywords(self) -> Dict[str, Any]:
+        """
+        Format the keywords with the constraints values.
+        """
+        import copy
+
+        if self.constraints.has_constraints:
+            constraints = self.constraints.dict()
+            keywords = copy.deepcopy(self.keywords)
+            keywords["constraints"] = constraints
+            return keywords
+        else:
+            return self.keywords
+
+
+class TorsionDriveEntry(DatasetEntry):
+    """
+    A Torsiondrive dataset specific class which can check dihedral indices and store torsiondrive specific settings with built in validation.
+    """
+
+    dihedrals: Optional[List[Tuple[int, int, int, int]]]
+    keywords: Optional[TDSettings] = TDSettings()
+
+    def __init__(self, off_molecule: Optional[off.Molecule] = None, **kwargs):
+
+        super().__init__(off_molecule, **kwargs)
+        # now validate the torsions check proper first
+        off_molecule = self.get_off_molecule(include_conformers=False)
+
+        # now validate the dihedrals
+        for torsion in self.dihedrals:
+            # check for linear torsions
+            check_linear_torsions(torsion, off_molecule)
+            try:
+                check_torsion_connection(torsion=torsion, molecule=off_molecule)
+            except DihedralConnectionError:
+                # if this fails as well raise
+                try:
+                    check_improper_connection(improper=torsion, molecule=off_molecule)
+                except DihedralConnectionError:
+                    raise DihedralConnectionError(
+                        f"The dihedral {torsion} for molecule {off_molecule} is not a valid"
+                        f" proper/improper torsion."
+                    )
+
+
+class FilterEntry(DatasetConfig):
+    """
+    A basic data class that contains information on components run in a workflow and the associated molecules which were
+    removed by it.
+    """
+
+    component_name: str
+    component_description: Dict[str, Any]
+    component_provenance: Dict[str, str]
+    molecules: List[str]
+
+    def __init__(self, off_molecules: List[off.Molecule] = None, **kwargs):
+        """
+        Init the dataclass handling conversions of the molecule first.
+        """
+        if off_molecules is not None:
+            molecules = [
+                molecule.to_smiles(isomeric=True, explicit_hydrogens=True)
+                for molecule in off_molecules
+            ]
+            kwargs["molecules"] = molecules
+
+        super().__init__(**kwargs)

--- a/qcsubmit/exceptions.py
+++ b/qcsubmit/exceptions.py
@@ -191,3 +191,21 @@ class PCMSettingError(QCSubmitException):
 
     error_type = "pcm_setting_error"
     header = "PCM Setting Error"
+
+
+class InvalidDatasetError(QCSubmitException):
+    """
+    The dataset can not be registered as it is not valid sub class of the Dataset
+    """
+
+    error_type = "invalid_dataset_error"
+    header = "Invalid Dataset Error"
+
+
+class DatasetRegisterError(QCSubmitException):
+    """
+    A dataset of this type has already been registered with qcsubmit
+    """
+
+    error_type = "dataset_register_error"
+    header = "Dataset Register Error"

--- a/qcsubmit/tests/test_datasets.py
+++ b/qcsubmit/tests/test_datasets.py
@@ -1487,7 +1487,7 @@ def test_dataset_export_full_dataset_json(dataset_type):
         attributes = get_cmiles(molecule)
         try:
             dataset.add_molecule(index=index, attributes=attributes, molecule=molecule)
-        except TypeError:
+        except ValidationError:
             dihedrals = [get_dihedral(molecule), ]
             dataset.add_molecule(index=index, attributes=attributes, molecule=molecule, dihedrals=dihedrals)
     with temp_directory():

--- a/qcsubmit/tests/test_results.py
+++ b/qcsubmit/tests/test_results.py
@@ -354,7 +354,6 @@ def test_torsiondrivedataset_new_torsiondrive(public_client):
     entry = new_dataset.dataset["[ch2:3]([ch2:2][oh:4])[oh:1]_12"]
     # make sure all starting molecules are present
     assert len(entry.initial_molecules) == 24
-    assert entry.constraints.has_constraints is False
 
 
 def test_torsiondrivedataset_new_optimization(public_client):


### PR DESCRIPTION
## Description
This PR changes how datasets are setup slightly to allow for more specific validation. We split out the dataset entry classes into 3 distinct types which have better validation. For example, only optimization datasets have entries with constraints and now torsiondrive entries must have a dihedral defined. Torsiondrive entries now have a defined set of keywords captured in the  `TDSettings` class rather than accepting a general dict to allow for validation of the unique scan settings which replace the general settings in the dataset.

Datasets should now be registered using the `register_dataset` function users can add there own as long as it is a subclass of `BasicDataset`.  Once registered the new util function `load_dataset` can instance the class from file or dict into the correct dataset rather than using `OptimizationDataset.parse_file` etc. 

I plan to also update factories to follow this pattern which should help with the CLI in future.

## Status
- [X] Ready to go