### PR TITLE
Basis set name logic

### DIFF
--- a/qcsubmit/datasets/datasets.py
+++ b/qcsubmit/datasets/datasets.py
@@ -648,13 +648,25 @@ class BasicDataset(IndexCleaner, ClientHandler, QCSpecificationHandler, DatasetC
                 # now check psi4
                 # TODO this list should be updated with more basis transforms as we find them
                 psi4_converter = {"dzvp": "dgauss-dzvp"}
+                month_subs = {"jun-", "mar-", "apr-", "may-", "feb-"}
                 basis = psi4_converter.get(spec.basis.lower(), spec.basis.lower())
                 # here we need to apply conversions for special characters to match bse
                 # replace the *
                 basis = re.sub("\*", "_st_", basis)
                 # replace any /
                 basis = re.sub("/", "_sl_", basis)
-                basis_meta = bse.get_metadata()[basis]
+                # check for heavy tags
+                basis = re.sub("heavy-", "", basis)
+                try:
+                    basis_meta = bse.get_metadata()[basis]
+                except KeyError:
+                    # now try and do month subs
+                    for month in month_subs:
+                        if month in basis:
+                            basis = re.sub(month, "", basis)
+                    # now try and get the basis again
+                    basis_meta = bse.get_metadata()[basis]
+
                 elements = basis_meta["versions"][basis_meta["latest_version"]][
                     "elements"
                 ]

--- a/qcsubmit/tests/test_datasets.py
+++ b/qcsubmit/tests/test_datasets.py
@@ -1658,7 +1658,14 @@ def test_dataset_roundtrip_compression(dataset_type, compression):
     pytest.param(({"method": "GFN2-xTB", "basis": None, "program": "xtb"}, {"C", "N", "Se"}, False), id="XTB Pass"),
     pytest.param(({"method": "uff", "basis": None, "program": "rdkit"}, {"C", "N", "O"}, False), id="Rdkit UFF Pass"),
     pytest.param(({"method": "hf", "basis": "6-311++G**", "program": "psi4"}, {"Br", "C", "O", "N"}, True), id="6-311++G** regex sub Error"),
-    pytest.param(({"method": "hf", "basis": "cc-pV5Z(fi/sf/fw)", "program": "psi4"}, {"Br", "C", "O", "N"}, False), id="cc-pV5Z(fi/sf/fw) regex Pass")
+    pytest.param(({"method": "hf", "basis": "cc-pV5Z(fi/sf/fw)", "program": "psi4"}, {"Br", "C", "O", "N"}, False), id="cc-pV5Z(fi/sf/fw) regex Pass"),
+    pytest.param(({"method": "hf", "basis": "heavy-aug-cc-pvtz", "program": "psi4"}, {"Br", "C", "O", "N"}, False),
+                 id="heavy-aug-cc-pvtz heavy regex Pass"),
+    pytest.param(({"method": "hf", "basis": "apr-cc-pV(5+d)Z", "program": "psi4"}, {"Br", "C", "O", "N"}, False),
+                 id="apr-cc-pV(5+d)Z regex Pass"),
+    pytest.param(({"method": "hf", "basis": "jun-cc-pV(Q+d)Z", "program": "psi4"}, {"Cl", "C", "O", "N", "Si"}, False),
+                 id="jun-cc-pV(Q+d)Z  Pass no regex"),
+
 ])
 def test_basis_coverage_single(basis_data):
     """


### PR DESCRIPTION
## Description
Here we improve the basis set coverage checking logic to handle cases such as the month or heavy basis sets. If we can not find the provided basis name we try some defined substitutions which attempt to strip the name down the core basis and validate based on this. There may still be some cases which cause errors but this [submission](https://github.com/openforcefield/qca-dataset-submission/pull/169) should now pass validation.

Fixes #69 

## Status
- [X] Ready to go