### PR TITLE
Pydantic Fields update

### DIFF
--- a/devtools/conda-envs/psi4_env.yaml
+++ b/devtools/conda-envs/psi4_env.yaml
@@ -23,6 +23,7 @@ dependencies:
   - qcportal >=0.13.0
   - qcengine >=0.15.0
   - psi4 >=1.4a2
+  - gau2grid ==2.0.3
   - pcmsolver ==1.2.1
   - openeye-toolkits ==2019.10.2
   - qcfractal >=0.13.0

--- a/devtools/conda-envs/psi4_env.yaml
+++ b/devtools/conda-envs/psi4_env.yaml
@@ -14,7 +14,7 @@ dependencies:
     # Testing
   - pytest
   - pytest-cov
-  - openforcefield >=0.7.0
+  - openforcefield ==0.8.3
   - openforcefields
   - openmmforcefields
   - smirnoff99Frosst
@@ -22,7 +22,7 @@ dependencies:
   - codecov
   - qcportal >=0.13.0
   - qcengine >=0.15.0
-  - psi4 ==1.4a3.dev61+2dd1fe1
+  - psi4 >=1.4a2
   - pcmsolver ==1.2.1
   - openeye-toolkits ==2019.10.2
   - qcfractal >=0.13.0

--- a/devtools/conda-envs/psi4_env.yaml
+++ b/devtools/conda-envs/psi4_env.yaml
@@ -22,7 +22,7 @@ dependencies:
   - codecov
   - qcportal >=0.13.0
   - qcengine >=0.15.0
-  - psi4 ==1.4a3.dev63+afa0c21
+  - psi4 ==1.4a3.dev61+2dd1fe1
   - pcmsolver ==1.2.1
   - openeye-toolkits ==2019.10.2
   - qcfractal >=0.13.0

--- a/devtools/conda-envs/psi4_env.yaml
+++ b/devtools/conda-envs/psi4_env.yaml
@@ -22,7 +22,7 @@ dependencies:
   - codecov
   - qcportal >=0.13.0
   - qcengine >=0.15.0
-  - psi4 ==1.4a3.dev1+8afefb7
+  - psi4 ==1.4a3.dev63+afaOc21
   - pcmsolver ==1.2.1
   - openeye-toolkits ==2019.10.2
   - qcfractal >=0.13.0

--- a/devtools/conda-envs/psi4_env.yaml
+++ b/devtools/conda-envs/psi4_env.yaml
@@ -22,7 +22,7 @@ dependencies:
   - codecov
   - qcportal >=0.13.0
   - qcengine >=0.15.0
-  - psi4 ==1.4a3.dev63+afaOc21
+  - psi4 ==1.4a3.dev63+afa0c21
   - pcmsolver ==1.2.1
   - openeye-toolkits ==2019.10.2
   - qcfractal >=0.13.0

--- a/qcsubmit/common_structures.py
+++ b/qcsubmit/common_structures.py
@@ -1074,7 +1074,7 @@ class CommonBase(DatasetConfig, IndexCleaner, ClientHandler, QCSpecificationHand
         DriverEnum.energy,
         description="The type of single point calculations which will be computed. Note some services require certain calculations for example optimizations require graident calculations.",
     )
-    scf_properties: List[Union[SCFProperties, str]] = Field(
+    scf_properties: List[SCFProperties] = Field(
         [
             SCFProperties.Dipole,
             SCFProperties.Quadrupole,

--- a/qcsubmit/datasets/datasets.py
+++ b/qcsubmit/datasets/datasets.py
@@ -6,7 +6,7 @@ import qcelemental as qcel
 import qcportal as ptl
 import tqdm
 from openforcefield import topology as off
-from pydantic import PositiveInt, constr, validator
+from pydantic import Field, constr, validator
 from qcfractal.interface import FractalClient
 from qcportal.models.common_models import (
     DriverEnum,
@@ -16,12 +16,10 @@ from qcportal.models.common_models import (
 from typing_extensions import Literal
 
 from ..common_structures import (
-    ClientHandler,
-    DatasetConfig,
-    IndexCleaner,
+    CommonBase,
     Metadata,
+    MoleculeAttributes,
     QCSpec,
-    QCSpecificationHandler,
     TorsionIndexer,
 )
 from ..constraints import Constraints
@@ -35,7 +33,6 @@ from ..exceptions import (
 from ..procedures import GeometricProcedure
 from ..results import SingleResult
 from ..serializers import deserialize, serialize
-from ..validators import scf_property_validator
 from .entries import DatasetEntry, FilterEntry, OptimizationEntry, TorsionDriveEntry
 
 
@@ -262,7 +259,7 @@ class ComponentResult:
         return f"<ComponentResult name='{self.component_name}' molecules='{self.n_molecules}' filtered='{self.n_filtered}'>"
 
 
-class BasicDataset(IndexCleaner, ClientHandler, QCSpecificationHandler, DatasetConfig):
+class BasicDataset(CommonBase):
     """
     The general qcfractal dataset class which contains all of the molecules and information about them prior to
     submission.
@@ -275,35 +272,38 @@ class BasicDataset(IndexCleaner, ClientHandler, QCSpecificationHandler, DatasetC
         The molecules in this dataset are all expanded so that different conformers are unique submissions.
     """
 
-    dataset_name: str = "BasicDataset"
-    dataset_tagline: constr(
-        min_length=8, regex="[a-zA-Z]"
-    ) = "OpenForcefield single point evaluations."
-    dataset_type: Literal["DataSet"] = "DataSet"
-    maxiter: PositiveInt = 200
-    driver: DriverEnum = DriverEnum.energy
-    scf_properties: List[str] = [
-        "dipole",
-        "quadrupole",
-        "wiberg_lowdin_indices",
-        "mayer_indices",
-    ]
-    priority: str = "normal"
-    description: constr(
-        min_length=8, regex="[a-zA-Z]"
-    ) = f"A basic dataset using the {driver} driver."
-    dataset_tags: List[str] = ["openff"]
-    compute_tag: str = "openff"
-    metadata: Metadata = Metadata()
-    provenance: Dict[str, str] = {}
-    dataset: Dict[str, DatasetEntry] = {}
-    filtered_molecules: Dict[str, FilterEntry] = {}
+    dataset_name: str = Field(
+        "BasicDataset",
+        description="The name of the dataset, this will be the name given to the collection in QCArchive.",
+    )
+    dataset_tagline: constr(min_length=8, regex="[a-zA-Z]") = Field(
+        "OpenForcefield single point evaluations.",
+        description="The tagline should be a short description of the dataset which will be displayed by the QCArchive client when the collections are listed.",
+    )
+    dataset_type: Literal["DataSet"] = Field(
+        "DataSet",
+        description="The dataset type corresponds to the type of collection that will be made in QCArchive.",
+    )
+    description: constr(min_length=8, regex="[a-zA-Z]") = Field(
+        f"A basic dataset of single points.",
+        description="A long description of the datasets purpose and details about the molecules within.",
+    )
+    metadata: Metadata = Field(
+        Metadata(), description="The metadata describing the dataset."
+    )
+    provenance: Dict[str, str] = Field(
+        {},
+        description="A dictionary of the software and versions used to generate the dataset.",
+    )
+    dataset: Dict[str, DatasetEntry] = Field(
+        {}, description="The actual dataset to be stored in QCArchive."
+    )
+    filtered_molecules: Dict[str, FilterEntry] = Field(
+        {},
+        description="The set of workflow components used to generate the dataset with any filtered molecules.",
+    )
     _file_writers = {"json": json.dump}
     _entry_class = DatasetEntry
-
-    _scf_validator = validator("scf_properties", each_item=True, allow_reuse=True)(
-        scf_property_validator
-    )
 
     def __init__(self, **kwargs):
         """
@@ -391,7 +391,7 @@ class BasicDataset(IndexCleaner, ClientHandler, QCSpecificationHandler, DatasetC
         inchi_key = molecule.to_inchikey(fixed_hydrogens=False)
         hits = []
         for entry in self.dataset.values():
-            if inchi_key == entry.attributes["inchi_key"]:
+            if inchi_key == entry.attributes.inchi_key:
                 # they have same basic inchi now match the molecule
                 if molecule == entry.get_off_molecule(include_conformers=False):
                     hits.append(entry.index)
@@ -459,7 +459,7 @@ class BasicDataset(IndexCleaner, ClientHandler, QCSpecificationHandler, DatasetC
         """
         molecules = {}
         for entry in self.dataset.values():
-            inchikey = entry.attributes["inchi_key"]
+            inchikey = entry.attributes.inchi_key
             try:
                 like_mols = molecules[inchikey]
                 mol_to_add = entry.get_off_molecule(False).to_inchikey(
@@ -567,7 +567,7 @@ class BasicDataset(IndexCleaner, ClientHandler, QCSpecificationHandler, DatasetC
         self,
         index: str,
         molecule: off.Molecule,
-        attributes: Dict[str, Any],
+        attributes: Union[Dict[str, Any], MoleculeAttributes],
         extras: Optional[Dict[str, Any]] = None,
         keywords: Optional[Dict[str, Any]] = None,
         **kwargs,
@@ -1119,8 +1119,7 @@ class BasicDataset(IndexCleaner, ClientHandler, QCSpecificationHandler, DatasetC
         """
 
         smiles = [
-            data.attributes["canonical_isomeric_smiles"]
-            for data in self.dataset.values()
+            data.attributes.canonical_isomeric_smiles for data in self.dataset.values()
         ]
         return smiles
 
@@ -1129,7 +1128,7 @@ class BasicDataset(IndexCleaner, ClientHandler, QCSpecificationHandler, DatasetC
         Create a list of the molecules standard InChI.
         """
 
-        inchi = [data.attributes["standard_inchi"] for data in self.dataset.values()]
+        inchi = [data.attributes.standard_inchi for data in self.dataset.values()]
         return inchi
 
     def _molecules_to_inchikey(self) -> List[str]:
@@ -1137,7 +1136,7 @@ class BasicDataset(IndexCleaner, ClientHandler, QCSpecificationHandler, DatasetC
         Create a list of the molecules standard InChIKey.
         """
 
-        inchikey = [data.attributes["inchi_key"] for data in self.dataset.values()]
+        inchikey = [data.attributes.inchi_key for data in self.dataset.values()]
         return inchikey
 
 
@@ -1156,9 +1155,12 @@ class OptimizationDataset(BasicDataset):
     description: constr(
         min_length=8, regex="[a-zA-Z]"
     ) = "An optimization dataset using geometric."
-    metadata: Metadata = Metadata(collection_type=dataset_type)
+    metadata: Metadata = Metadata()
     driver: DriverEnum = DriverEnum.gradient
-    optimization_procedure: GeometricProcedure = GeometricProcedure()
+    optimization_procedure: GeometricProcedure = Field(
+        GeometricProcedure(),
+        description="The optimization program and settings that should be used.",
+    )
     _entry_class = OptimizationEntry
 
     @validator("driver")
@@ -1413,7 +1415,7 @@ class OptimizationDataset(BasicDataset):
                     collection.add_entry(
                         name=name,
                         initial_molecule=molecule,
-                        attributes=data.attributes,
+                        attributes=data.attributes.dict(),
                         additional_keywords=data.formatted_keywords,
                         save=False,
                     )
@@ -1462,10 +1464,22 @@ class TorsiondriveDataset(OptimizationDataset):
     optimization_procedure: GeometricProcedure = GeometricProcedure.parse_obj(
         {"enforce": 0.1, "reset": True, "qccnv": True, "epsilon": 0.0}
     )
-    grid_spacing: List[int] = [15]
-    energy_upper_limit: float = 0.05
-    dihedral_ranges: Optional[List[Tuple[int, int]]] = None
-    energy_decrease_thresh: Optional[float] = None
+    grid_spacing: List[int] = Field(
+        [15],
+        description="The grid spcaing that should be used for all torsiondrives, this can be overwriten on a per entry basis.",
+    )
+    energy_upper_limit: float = Field(
+        0.05,
+        description="The upper energy limit to spawn new optimizations in the torsiondrive.",
+    )
+    dihedral_ranges: Optional[List[Tuple[int, int]]] = Field(
+        None,
+        description="The scan range that should be used for each torsiondrive, this can be overwriten on a per entry basis.",
+    )
+    energy_decrease_thresh: Optional[float] = Field(
+        None,
+        description="The energy lower threshold to trigger new optimizations in the torsiondrive.",
+    )
     _entry_class = TorsionDriveEntry
 
     def __add__(self, other: "TorsiondriveDataset") -> "TorsiondriveDataset":
@@ -1607,7 +1621,7 @@ class TorsiondriveDataset(OptimizationDataset):
                     grid_spacing=data.keywords.grid_spacing or self.grid_spacing,
                     energy_upper_limit=data.keywords.energy_upper_limit
                     or self.energy_upper_limit,
-                    attributes=data.attributes,
+                    attributes=data.attributes.dict(),
                     energy_decrease_thresh=data.keywords.energy_decrease_thresh
                     or self.energy_decrease_thresh,
                     dihedral_ranges=data.keywords.dihedral_ranges

--- a/qcsubmit/factories.py
+++ b/qcsubmit/factories.py
@@ -8,7 +8,7 @@ from qcportal import FractalClient
 from qcportal.models.common_models import DriverEnum
 from typing_extensions import Literal
 
-from .common_structures import CommonBase, Metadata, MoleculeAttributes, SCFProperties
+from .common_structures import CommonBase, Metadata, MoleculeAttributes
 from .datasets import (
     BasicDataset,
     ComponentResult,

--- a/qcsubmit/tests/test_datasets.py
+++ b/qcsubmit/tests/test_datasets.py
@@ -10,7 +10,7 @@ from openforcefield.topology import Molecule
 from pydantic import ValidationError
 from simtk import unit
 
-from qcsubmit.common_structures import TorsionIndexer
+from qcsubmit.common_structures import MoleculeAttributes, TorsionIndexer
 from qcsubmit.constraints import Constraints, PositionConstraintSet
 from qcsubmit.datasets import (
     BasicDataset,
@@ -81,7 +81,7 @@ def get_dihedral(molecule: Molecule) -> Tuple[int, int, int, int]:
     return tuple(dihedral)
 
 
-def get_cmiles(molecule: Molecule) -> Dict[str, str]:
+def get_cmiles(molecule: Molecule) -> MoleculeAttributes:
     """
     Generate a valid and full cmiles for the given molecule.
     """
@@ -1309,7 +1309,7 @@ def test_dataset_nmolecules_tautomers():
     for molecule in molecules:
         index = molecule.to_smiles()
         attributes = get_cmiles(molecule)
-        attributes["inchi_key"] = same_inchi
+        attributes.inchi_key = same_inchi
         dataset.add_molecule(index=index, attributes=attributes, molecule=molecule)
 
     assert dataset.n_molecules == len(molecules)
@@ -1418,7 +1418,7 @@ def test_basicdataset_add_molecule_missing_attributes():
     assert ethane.n_conformers != 0
     index = ethane.to_smiles()
     attributes = {"test": "test"}
-    with pytest.raises(DatasetInputError):
+    with pytest.raises(ValidationError):
         dataset.add_molecule(index=index, attributes=attributes, molecule=ethane)
 
 

--- a/qcsubmit/tests/test_factories.py
+++ b/qcsubmit/tests/test_factories.py
@@ -22,7 +22,7 @@ from qcsubmit.testing import temp_directory
 from qcsubmit.utils import get_data
 
 
-def test_scf_properties_asignment():
+def test_scf_properties_assignment():
     """Test adding different scf_properties and make sure they are validated correctly."""
 
     factory = BasicDatasetFactory()

--- a/qcsubmit/tests/test_submissions.py
+++ b/qcsubmit/tests/test_submissions.py
@@ -130,7 +130,7 @@ def test_basic_submissions_multiple_spec(fractal_compute_server):
                                      description="Test basics dataset",
                                      tagline="Testing single point datasets",
                                      )
-
+    print(dataset.scf_properties)
     with pytest.raises(DatasetInputError):
         dataset.submit(client=client, await_result=False)
 

--- a/qcsubmit/tests/test_submissions.py
+++ b/qcsubmit/tests/test_submissions.py
@@ -836,7 +836,7 @@ def test_ignore_errors_all_datasets(fractal_compute_server, factory_type):
     factory.clear_qcspecs()
     # add only mm specs
     factory.add_qc_spec(method="openff-1.0.0", basis="smirnoff", program="openmm", spec_name="parsley", spec_description="standard parsley spec")
-    dataset = factory.create_dataset(dataset_name=f"Test ignore_error for {factory.Config.title}",
+    dataset = factory.create_dataset(dataset_name=f"Test ignore_error for {factory.factory_type}",
                                      molecules=molecule,
                                      description="Test ignore errors dataset",
                                      tagline="Testing ignore errors datasets",

--- a/qcsubmit/validators.py
+++ b/qcsubmit/validators.py
@@ -19,66 +19,33 @@ from .exceptions import (
     MolecularComplexError,
 )
 
-
-def cmiles_validator(cmiles: Dict[str, str]) -> Dict[str, str]:
-    """
-    Validate the cmiles attributes for a molecule submission.
-
-    Parameters:
-        cmiles: The cmiles attributes for the molecule which is to be submitted.
-
-    Raises:
-        DatasetInputError: If the cmiles is missing a field.
-    """
-
-    expected_cmiles = {
-        "canonical_smiles",
-        "canonical_isomeric_smiles",
-        "canonical_explicit_hydrogen_smiles",
-        "canonical_isomeric_explicit_hydrogen_smiles",
-        "canonical_isomeric_explicit_hydrogen_mapped_smiles",
-        "molecular_formula",
-        "standard_inchi",
-        "inchi_key",
-    }
-    # use set logic to find missing expected attributes from cmiles
-    supplied_cmiles = set(cmiles.keys())
-    difference = expected_cmiles.difference(supplied_cmiles)
-    if difference:
-        raise DatasetInputError(
-            f"The supplied cmiles is missing the following fields {difference}."
-        )
-
-    return cmiles
-
-
-def scf_property_validator(scf_property: str) -> str:
-    """
-    Validate a single scf property this is used for each in a list and also for adding  a new property.
-
-    Parameters:
-        scf_property: The scf property which is to be added.
-
-    Raises:
-        DatasetInputError: If the scf property is not correct.
-    """
-
-    allowed_properties = [
-        "dipole",
-        "quadrupole",
-        "mulliken_charges",
-        "lowdin_charges",
-        "wiberg_lowdin_indices",
-        "mayer_indices",
-        "mbis_charges",
-    ]
-
-    if scf_property.lower() not in allowed_properties:
-        raise DatasetInputError(
-            f"The requested scf_property {scf_property} is not valid please chose from {allowed_properties}."
-        )
-
-    return scf_property.lower()
+# def scf_property_validator(scf_property: str) -> str:
+#     """
+#     Validate a single scf property this is used for each in a list and also for adding  a new property.
+#
+#     Parameters:
+#         scf_property: The scf property which is to be added.
+#
+#     Raises:
+#         DatasetInputError: If the scf property is not correct.
+#     """
+#
+#     allowed_properties = [
+#         "dipole",
+#         "quadrupole",
+#         "mulliken_charges",
+#         "lowdin_charges",
+#         "wiberg_lowdin_indices",
+#         "mayer_indices",
+#         "mbis_charges",
+#     ]
+#
+#     if scf_property.lower() not in allowed_properties:
+#         raise DatasetInputError(
+#             f"The requested scf_property {scf_property} is not valid please chose from {allowed_properties}."
+#         )
+#
+#     return scf_property.lower()
 
 
 def check_improper_connection(

--- a/qcsubmit/validators.py
+++ b/qcsubmit/validators.py
@@ -2,7 +2,7 @@
 Centralise the validators for easy reuse between factories and datasets.
 """
 
-from typing import Dict, List, Tuple
+from typing import List, Tuple
 
 import qcelemental as qcel
 from openforcefield import topology as off
@@ -13,39 +13,10 @@ from .exceptions import (
     AtomConnectionError,
     BondConnectionError,
     ConstraintError,
-    DatasetInputError,
     DihedralConnectionError,
     LinearTorsionError,
     MolecularComplexError,
 )
-
-# def scf_property_validator(scf_property: str) -> str:
-#     """
-#     Validate a single scf property this is used for each in a list and also for adding  a new property.
-#
-#     Parameters:
-#         scf_property: The scf property which is to be added.
-#
-#     Raises:
-#         DatasetInputError: If the scf property is not correct.
-#     """
-#
-#     allowed_properties = [
-#         "dipole",
-#         "quadrupole",
-#         "mulliken_charges",
-#         "lowdin_charges",
-#         "wiberg_lowdin_indices",
-#         "mayer_indices",
-#         "mbis_charges",
-#     ]
-#
-#     if scf_property.lower() not in allowed_properties:
-#         raise DatasetInputError(
-#             f"The requested scf_property {scf_property} is not valid please chose from {allowed_properties}."
-#         )
-#
-#     return scf_property.lower()
 
 
 def check_improper_connection(


### PR DESCRIPTION
## Description
This PR will change all schemas to use pydantic fields to fully define the model this should also help with the documentation.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [X] Update all schema to use pydantic fields
  - [X] Introduce a cmiles schema to hold the molecule attributes, this is expandable beyond the defined model
  - [X] Introduce a SCF Property enum so its easier for users to work out what is available, this also helps validation
  - [X] SCF Properties can now be added and removed from datasets.
  - [X] Remove old validators.

## Status
- [ ] Ready to go